### PR TITLE
Include *.properties resources in src/main/java

### DIFF
--- a/rt/pom.xml
+++ b/rt/pom.xml
@@ -27,6 +27,12 @@
         <directory>src/main/resources</directory>
       </resource>
       <resource>
+        <directory>src/main/java</directory>
+        <includes>
+          <include>**/*.properties</include>
+        </includes>
+      </resource>
+      <resource>
         <directory>src/filtered-java/</directory>
         <targetPath>${project.build.directory}/generated-sources/filtered-java</targetPath>
         <filtering>true</filtering>


### PR DESCRIPTION
In particular, trying to use java.util.logging needs logging.properties.
