### PR TITLE
added the CFBundleVersion to the default plist

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -391,6 +391,7 @@ public class IOSTarget extends AbstractTarget {
                 dict.put(key, infoPListDict.objectForKey(key));
             }
         } else {
+            dict.put("CFBundleVersion", "1.0");
             dict.put("CFBundleExecutable", config.getExecutableName());
             dict.put("CFBundleName", config.getExecutableName());
             dict.put("CFBundleIdentifier", getBundleId());


### PR DESCRIPTION
-iOS7 simulator required the bundle version to exist so a default value
of 1.0 will be added if no plist is provided
