### PR TITLE
Parse properties from the correct offset

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -270,7 +270,7 @@ public class AppCompiler {
                     if (index <= 0) {
                         throw new IllegalArgumentException("Malformed property: " + args[i]);
                     }
-                    String name = args[i].substring(0, index);
+                    String name = args[i].substring(2, index);
                     String value = args[i].substring(index + 1);
                     builder.addProperty(name, value);
                 } else if ("-debug".equals(args[i])) {


### PR DESCRIPTION
This fixes a small bug preventing the -Pname=value flag from working correctly, because it includes the "-P" in the property name. The workaround I'm using right now is to write my properties as ${-Papp.name} instead of ${app.name}.
