### PR TITLE
Add toObject marshaler to VoidBlock

### DIFF
--- a/objc/src/main/java/org/robovm/objc/block/VoidBlock.java
+++ b/objc/src/main/java/org/robovm/objc/block/VoidBlock.java
@@ -44,5 +44,9 @@ public interface VoidBlock {
         public static @Pointer long toNative(Object o, long flags) {
             return WRAPPER.toNative(o);
         }
+
+        public static Object toObject(Class cls, long handle, long flags) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Simply return null to prevent 
`NoSuchMethodError: org.robovm.objc.block.VoidBlock$Marshaler.toObject(...)` exception from occurring.

This addresses Issue #235
