### PR TITLE
Disabled IPA tests until they can be rewritten to re-sign demo.ipa

### DIFF
--- a/libimobiledevice/src/test/java/org/robovm/libimobiledevice/InstallationProxyClientTest.java
+++ b/libimobiledevice/src/test/java/org/robovm/libimobiledevice/InstallationProxyClientTest.java
@@ -92,7 +92,7 @@ public class InstallationProxyClientTest {
         assertNotNull(safari);
     }
 
-    @Test
+    //removed as test until it can be rewritten to re-sign the ipa
     public void testUpgradeIPA() throws Exception {
         Path tmpDir = Files.createTempDirectory(getClass().getSimpleName());
         Files.copy(getClass().getResourceAsStream("/demo.ipa"), tmpDir.resolve("demo.ipa"));
@@ -131,7 +131,7 @@ public class InstallationProxyClientTest {
         assertTrue(success[0]);
     }
     
-    @Test
+    //removed as test until it can be rewritten to re-sign the ipa
     public void testUpgradeAppBundle() throws Exception {
         Path tmpDir = Files.createTempDirectory(getClass().getSimpleName());
         Path ipaFile = tmpDir.resolve("demo.ipa");
@@ -174,6 +174,7 @@ public class InstallationProxyClientTest {
         countDownLatch.await(10, TimeUnit.SECONDS);
         assertTrue(success[0]);
     }
+
     
     protected void extractZip(Path zipFile, Path outDir) throws IOException {
         try (ZipFile archive = new ZipFile(zipFile.toFile())) {


### PR DESCRIPTION
The libimobiledevice tests currently fail if they are not Niklas's device. Disabled them for now, they could be refactored later to re-sign the demo.ipa
