### PR TITLE
Reduced uploading to device log spam see #242

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -192,6 +192,7 @@ public class IOSTarget extends AbstractTarget {
             .xcodePath(ToolchainUtil.findXcodePath())
             .uploadProgressCallback(new UploadProgressCallback() {
                 boolean first = true;
+		int lastProgress = 0;
                 public void success() {
                     config.getLogger().debug("[100%%] Upload complete");
                 }
@@ -200,7 +201,10 @@ public class IOSTarget extends AbstractTarget {
                         config.getLogger().debug("[  0%%] Beginning upload...");
                     }
                     first = false;
-                    config.getLogger().debug("[%3d%%] Uploading %s...", percentComplete, path);
+		    if(percentComplete >= lastProgress + 5) {
+                        config.getLogger().debug("[%3d%%] Uploading %s...", percentComplete, path);
+			lastProgress = percentComplete;
+		    }
                 }
                 public void error(String message) {
                 }


### PR DESCRIPTION
Minor thing, but it annoyed me during development a few times when I wanted to see the provisioning profile / identity logging that happens right before this.

Reduces logging of upload progress to every 5 percent.
