### PR TITLE
Rename interface (windows keyword)

### DIFF
--- a/vm/core/include/robovm/class.h
+++ b/vm/core/include/robovm/class.h
@@ -157,7 +157,7 @@ extern BridgeMethod* rvmAllocateBridgeMethod(Env* env, Class* clazz, const char*
         void* synchronizedImpl, void** targetFnPtr, void* attributes);
 extern CallbackMethod* rvmAllocateCallbackMethod(Env* env, Class* clazz, const char* name, const char* desc, jint vitableIndex, jint access, jint size, void* impl, 
 		void* synchronizedImpl, void* callbackImpl, void* attributes);
-extern jboolean rvmAddInterface(Env* env, Class* clazz, Class* interface);
+extern jboolean rvmAddInterface(Env* env, Class* clazz, Class* interf);
 extern Field* rvmAddField(Env* env, Class* clazz, const char* name, const char* desc, jint access, jint offset, void* attributes);
 extern Method* rvmAddMethod(Env* env, Class* clazz, const char* name, const char* desc, jint vitableIndex, jint access, jint size, void* impl, void* synchronizedImpl, void* attributes);
 extern BridgeMethod* rvmAddBridgeMethod(Env* env, Class* clazz, const char* name, const char* desc, jint vitableIndex, jint access, jint size, void* impl, 

--- a/vm/core/include/robovm/types.h
+++ b/vm/core/include/robovm/types.h
@@ -118,7 +118,7 @@ struct ProxyMethodException {
 
 struct Interface {
   Interface* next;
-  Class* interface;
+  Class* interfaceClass;
 };
 
 struct Object {

--- a/vm/core/src/class.c
+++ b/vm/core/src/class.c
@@ -850,10 +850,10 @@ Class* rvmAllocateClass(Env* env, const char* className, Class* superclass, Clas
 }
 
 Interface* rvmAllocateInterface(Env* env, Class* interf) {
-    Interface* interface = rvmAllocateMemoryAtomicUncollectable(env, sizeof(Interface));
-    if (!interface) return NULL;
-    interface->interface = interf;
-    return interface;
+    Interface* interf = rvmAllocateMemoryAtomicUncollectable(env, sizeof(Interface));
+    if (!interf) return NULL;
+    interf->interfaceClass = interf;
+    return interf;
 }
 
 jboolean rvmAddInterface(Env* env, Class* clazz, Class* interf) {
@@ -863,12 +863,12 @@ jboolean rvmAddInterface(Env* env, Class* clazz, Class* interf) {
         rvmThrowIncompatibleClassChangeError(env, "");
         return FALSE;
     }
-    Interface* interface = rvmAllocateInterface(env, interf);
-    if (!interface) return FALSE;
+    Interface* ift = rvmAllocateInterface(env, interf);
+    if (!ift) return FALSE;
     if (clazz->_interfaces == &INTERFACES_NOT_LOADED) {
         clazz->_interfaces = NULL;
     }
-    LL_APPEND(clazz->_interfaces, interface);
+    LL_APPEND(clazz->_interfaces, ift);
     return TRUE;
 }
 

--- a/vm/core/src/field.c
+++ b/vm/core/src/field.c
@@ -25,10 +25,10 @@ static Field* getField(Env* env, Class* clazz, char* name, char* desc) {
         }
     }
 
-    Interface* interface = rvmGetInterfaces(env, clazz);
+    Interface* interf = rvmGetInterfaces(env, clazz);
     if (rvmExceptionCheck(env)) return NULL;
-    for (; interface != NULL; interface = interface->next) {
-        field = getField(env, interface->interface, name, desc);
+    for (; interf != NULL; interf = interf->next) {
+        field = getField(env, interf->interfaceClass, name, desc);
         if (rvmExceptionCheck(env)) return NULL;
         if (field) return field;
     }

--- a/vm/core/src/init.c
+++ b/vm/core/src/init.c
@@ -205,7 +205,6 @@ Env* rvmStartup(Options* options) {
 
     TRACE("Initializing GC");
     if (!initGC(options)) return NULL;
-
     // Ignore SIGPIPE signals. SIGPIPE interrupts write() calls which we don't
     // want. Dalvik does this too in dalvikvm/Main.cpp.
     if (!ignoreSignal(SIGPIPE)) return NULL;

--- a/vm/core/src/method.c
+++ b/vm/core/src/method.c
@@ -81,10 +81,10 @@ static Method* getMethod(Env* env, Class* clazz, const char* name, const char* d
      * TODO: Should we really do this? Does the JNI GetMethodID() function do this?
      */
     for (c = clazz; c != NULL; c = c->superclass) {
-        Interface* interface = rvmGetInterfaces(env, c);
+        Interface* interf = rvmGetInterfaces(env, c);
         if (rvmExceptionCheck(env)) return NULL;
-        for (; interface != NULL; interface = interface->next) {
-            Method* method = getMethod(env, interface->interface, name, desc);
+        for (; interf != NULL; interf = interf->next) {
+            Method* method = getMethod(env, interf->interfaceClass, name, desc);
             if (rvmExceptionCheck(env)) return NULL;
             if (method) return method;
         }

--- a/vm/rt/robovm/java_lang_Class.c
+++ b/vm/rt/robovm/java_lang_Class.c
@@ -119,16 +119,16 @@ Object* Java_java_lang_Class_getEnclosingConstructor(Env* env, Class* thiz) {
 ObjectArray* Java_java_lang_Class_getInterfaces(Env* env, Class* thiz) {
     Interface* interfaces = rvmGetInterfaces(env, thiz);
     if (rvmExceptionCheck(env)) return NULL;
-    Interface* interface;
+    Interface* interf;
     jint length = 0;
-    LL_FOREACH(interfaces, interface) {
+    LL_FOREACH(interfaces, interf) {
         length++;
     }
     ObjectArray* result = rvmNewObjectArray(env, length, java_lang_Class, NULL, NULL);
     if (!result) return NULL;
     jint i = 0;
-    LL_FOREACH(interfaces, interface) {
-        result->values[i++] = (Object*) interface->interface;
+    LL_FOREACH(interfaces, interf) {
+        result->values[i++] = (Object*) interf->interfaceClass;
     }
     return result;
 }


### PR DESCRIPTION
Replace interface in the code as it is a compiler keyword on windows.

I extracted that PR from my current repository. I cannot test it on windows, as that PR is not enough to have a full valid windows build (and gcc spouts so many errors that I cannot see if I didn't forget some references).

Anyway, I think that's the very first step to have robovm building on windows :) 
