### PR TITLE
Update SHA1PRNG_SecureRandomImpl to patch fix for CVE-2013-7372

### DIFF
--- a/rt/libcore/luni/src/main/java/org/apache/harmony/security/provider/crypto/SHA1Constants.java
+++ b/rt/libcore/luni/src/main/java/org/apache/harmony/security/provider/crypto/SHA1Constants.java
@@ -1,0 +1,82 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+* @author Yuri A. Kropachev
+* @version $Revision$
+*/
+
+
+package org.apache.harmony.security.provider.crypto;
+
+
+/**
+ * This interface contains : <BR>
+ * - a set of constant values, H0-H4, defined in "SECURE HASH STANDARD", FIPS PUB 180-2 ;<BR>
+ * - implementation constant values to use in classes using SHA-1 algorithm.    <BR>
+ */
+public final class SHA1Constants {
+    private SHA1Constants() {
+    }
+
+    /**
+     *  constant defined in "SECURE HASH STANDARD"
+     */
+    public static final int H0 = 0x67452301;
+
+
+    /**
+     *  constant defined in "SECURE HASH STANDARD"
+     */
+    public static final int H1 = 0xEFCDAB89;
+
+
+    /**
+     *  constant defined in "SECURE HASH STANDARD"
+     */
+    public static final int H2 = 0x98BADCFE;
+
+
+    /**
+     *  constant defined in "SECURE HASH STANDARD"
+     */
+    public static final int H3 = 0x10325476;
+
+
+    /**
+     *  constant defined in "SECURE HASH STANDARD"
+     */
+    public static final int H4 = 0xC3D2E1F0;
+
+
+    /**
+     * offset in buffer to store number of bytes in 0-15 word frame
+     */
+    public static final int BYTES_OFFSET = 81;
+
+
+    /**
+     * offset in buffer to store current hash value
+     */
+    public static final int HASH_OFFSET = 82;
+
+
+    /**
+     * # of bytes in H0-H4 words; <BR>
+     * in this implementation # is set to 20 (in general # varies from 1 to 20)
+     */
+    public static final int DIGEST_LENGTH = 20;
+}


### PR DESCRIPTION
Patch for vulnerability in SHA1PRNG_SecureRandomImpl caused when no seed if provided by the user.
More information available: http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-7372. 
The fix originated in this commit to the Android libcore: https://android.googlesource.com/platform/libcore/+/ab6d7714b47c04cc4bd812b32e6a6370181a06e4%5E%21/#F0
