### PR TITLE
fixed issue #20, check that access target is not in boot classpath

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/Access.java
+++ b/compiler/src/main/java/org/robovm/compiler/Access.java
@@ -16,6 +16,7 @@
  */
 package org.robovm.compiler;
 
+import org.robovm.compiler.clazz.Clazz;
 import org.robovm.compiler.clazz.ClazzInfo;
 
 import soot.ClassMember;
@@ -23,79 +24,82 @@ import soot.SootClass;
 
 /**
  * @author niklas
- *
+ * 
  */
 public class Access {
     public static final String ILLEGAL_ACCESS_ERROR_FIELD = "Attempt to access field %s.%s from class %s";
     public static final String ILLEGAL_ACCESS_ERROR_METHOD = "Attempt to access method %s.%s%s from class %s";
     public static final String ILLEGAL_ACCESS_ERROR_CLASS = "Attempt to access class %s from class %s";
 
-    public static boolean checkClassAccessible(SootClass target, SootClass caller) {
+    public static boolean checkClassAccessible(Clazz target, Clazz caller) {
         if (caller == target) {
-            return true; 
+            return true;
         }
-        if (target.isPublic()) {
-            return true; 
+        if (target.getSootClass().isPublic()) {
+            return true;
         }
-        if (target.getPackageName().equals(caller.getPackageName())) {
+        if (target.getSootClass().getPackageName().equals(caller.getSootClass().getPackageName()) &&
+                !target.isInBootClasspath()) {
             return true;
         }
         return false;
     }
-    
+
     public static boolean checkClassAccessible(ClazzInfo target, ClazzInfo caller) {
         if (caller == target) {
-            return true; 
+            return true;
         }
         if (target.isPublic()) {
-            return true; 
+            return true;
         }
         if (target.getPackageName().equals(caller.getPackageName())) {
+            if (!target.isPhantom() && target.getClazz().isInBootClasspath()) {
+                return false;
+            }
             return true;
         }
         return false;
     }
-    
-    public static boolean checkMemberAccessible(ClassMember member, SootClass caller, 
-            SootClass runtimeClass) {
-        
-        SootClass target = member.getDeclaringClass();
-        
+
+    public static boolean checkMemberAccessible(ClassMember member, Clazz caller, Clazz target,
+            SootClass runtimeClass) {        
+
         if (caller == target || member.isPublic()) {
             return true;
         }
-        
+
         if (!member.isPrivate()) {
             // Package private or protected
-            if (target.getPackageName().equals(caller.getPackageName())) {
+            if (target.getSootClass().getPackageName().equals(caller.getSootClass().getPackageName()) &&
+                !target.isInBootClasspath()) {
                 return true;
             }
             if (member.isProtected()) {
                 if (member.isStatic()) {
-                    if (isSubClassOrSame(target, caller)) {
+                    if (isSubClassOrSame(target.getSootClass(), caller.getSootClass())) {
                         return true;
                     }
-                } else if (isSubClassOrSame(target, caller)) {
+                } else if (isSubClassOrSame(target.getSootClass(), caller.getSootClass())) {
                     // Need to check that runtime class is a subclass of caller
                     if (runtimeClass == null) {
-                        // Either the runtime class is an array or invokestatic 
-                        // or getstatic/putstatic is used to call a non-static 
-                        // protected method or access a non-static field. We just
-                        // return true here and assume that other code will 
+                        // Either the runtime class is an array or invokestatic
+                        // or getstatic/putstatic is used to call a non-static
+                        // protected method or access a non-static field. We
+                        // just
+                        // return true here and assume that other code will
                         // check these things.
                         return true;
                     }
-                    if (isSubClassOrSame(caller, runtimeClass)) {
+                    if (isSubClassOrSame(caller.getSootClass(), runtimeClass)) {
                         return true;
                     }
                 }
             }
         }
-        
+
         return false;
     }
-    
-    
+
     public static boolean isSubClassOrSame(SootClass superclass, SootClass clazz) {
         while (clazz != null && !clazz.isPhantom() && clazz.hasSuperclass() && clazz != superclass) {
             clazz = clazz.getSuperclass();

--- a/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
+++ b/compiler/src/main/java/org/robovm/compiler/TrampolineCompiler.java
@@ -467,7 +467,7 @@ public class TrampolineCompiler {
             targetClassName = getBaseType(targetClassName);
         }
         Clazz target = config.getClazzes().load(targetClassName);
-        if (Access.checkClassAccessible(target.getSootClass(), caller.getSootClass())) {
+        if (Access.checkClassAccessible(target, caller)) {
             return true;
         }
         throwIllegalAccessError(f, ILLEGAL_ACCESS_ERROR_CLASS, 
@@ -477,7 +477,8 @@ public class TrampolineCompiler {
     }
 
     private boolean checkMemberAccessible(Function f, Trampoline t, ClassMember member) {
-        SootClass caller = config.getClazzes().load(t.getCallingClass()).getSootClass();
+        Clazz caller = config.getClazzes().load(t.getCallingClass());
+        Clazz target = config.getClazzes().load(t.getTarget());
 
         String runtimeClassName = null;
         runtimeClassName = t instanceof Invokevirtual 
@@ -500,7 +501,7 @@ public class TrampolineCompiler {
             runtimeClass = c.getSootClass();
         }
         
-        if (Access.checkMemberAccessible(member, caller, runtimeClass)) {
+        if (Access.checkMemberAccessible(member, caller, target, runtimeClass)) {
             return true;
         }
 

--- a/compiler/src/main/java/org/robovm/compiler/clazz/ClazzInfo.java
+++ b/compiler/src/main/java/org/robovm/compiler/clazz/ClazzInfo.java
@@ -90,6 +90,13 @@ public class ClazzInfo implements Serializable {
         this.clazz = clazz;
     }
     
+    /**
+     * @return Clazz or null if this is a phantom class 
+     */
+    public Clazz getClazz() {
+    	return clazz;
+    }
+    
     public int getModifiers() {
         return modifiers;
     }


### PR DESCRIPTION
I tested this by running the dalvik test suite as well as compile a libGDX project with it (which meant installing a locally compiled version of the Eclipse plugin, is there a better way to test this?).

I think the only "problematic" bit should be the additional parameter to `Access#checkMemberAccessible`. I couldn't get the required information from the other parameters. Is runtimeClass used for accessing shadowed members?
