### PR TITLE
Allow calling 'requestAccessToAccountsWithType:options:completion:' with options set to null (nil) without causing NPE

### DIFF
--- a/cocoatouch/src/main/java/org/robovm/apple/accounts/ACAccountStore.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/accounts/ACAccountStore.java
@@ -55,7 +55,11 @@ import org.robovm.apple.foundation.*;
         return getAccountType(typeIdentifier.value());
     }
     public void requestAccessToAccounts(ACAccountType accountType, ACAccountOptions options, @Block VoidBlock2<Boolean, NSError> completion) {
-        requestAccessToAccounts(accountType, options.data, completion);
+        if (options == null) {
+            requestAccessToAccounts(accountType, null, completion);
+        } else {
+            requestAccessToAccounts(accountType, options.data, completion);
+        }
     }
     /*<methods>*/
     @Method(selector = "accountWithIdentifier:")


### PR DESCRIPTION
According to Apple's API documentation, 'if the account type does not require an options dictionary, the options parameter must be nil'. It looks like a recent change has broken this for account types that do not require an options dictionary (like Twitter).
