### PR TITLE
Added prefix support for plugin arguments

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -497,12 +497,12 @@ public class AppCompiler {
                     runArgs.add(args[i]);
                 } else if (args[i].startsWith("-")) {
                     String argName = args[i].substring(1, args[i].length());
+                    if(argName.contains("=")) {
+                        argName = argName.substring(0, argName.indexOf('='));
+                    }
                     CompilerPluginArgument arg = pluginArguments.get(argName);
                     if (arg != null) {
-                        builder.addCompilerPluginArgument(argName);
-                        if(arg.hasValue()) {
-                            builder.addCompilerPluginArgument(args[++i]);
-                        }
+                        builder.addCompilerPluginArgument(args[i].substring(1));                        
                     } else {
                         throw new IllegalArgumentException("Unrecognized option: " + args[i]);
                     }
@@ -752,9 +752,9 @@ public class AppCompiler {
         
         if(plugins != null) {
             for(CompilerPlugin plugin: plugins) {
-                if(plugin.getArguments().size() > 0) {
+                if(plugin.getArguments().getArguments().size() > 0) {
                     System.err.println(plugin.getClass().getSimpleName() + " options:");
-                    for(CompilerPluginArgument arg: plugin.getArguments()) {
+                    for(CompilerPluginArgument arg: plugin.getArguments().getArguments()) {
                         String argString = "  -" + arg.getName() + (arg.hasValue()? " " + arg.getValueName(): "");
                         int whitespace = Math.max(1, 24 - argString.length());
                         System.err.println(argString + repeat(" ", whitespace) + arg.getDescription());

--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -1254,8 +1254,8 @@ public class Config {
         public Map<String, CompilerPluginArgument> fetchPluginArguments() {
             Map<String, CompilerPluginArgument> args = new TreeMap<>();
             for (CompilerPlugin plugin : config.compilerPlugins) {
-                for (CompilerPluginArgument arg : plugin.getArguments()) {
-                    args.put(arg.getName(), arg);
+                for (CompilerPluginArgument arg : plugin.getArguments().getArguments()) {
+                    args.put(plugin.getArguments().getPrefix() + ":" + arg.getName(), arg);
                 }
             }
             return args;

--- a/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
+++ b/compiler/src/main/java/org/robovm/compiler/plugin/AbstractCompilerPlugin.java
@@ -18,7 +18,6 @@ package org.robovm.compiler.plugin;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 
 import org.robovm.compiler.ModuleBuilder;
 import org.robovm.compiler.clazz.Clazz;
@@ -33,8 +32,8 @@ import soot.SootMethod;
  */
 public abstract class AbstractCompilerPlugin implements CompilerPlugin {
     @Override
-    public List<CompilerPluginArgument> getArguments() {
-        return Collections.emptyList();
+    public CompilerPluginArguments getArguments() {
+        return new CompilerPluginArguments("", Collections.<CompilerPluginArgument>emptyList());
     }
     
     @Override

--- a/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
+++ b/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPlugin.java
@@ -33,9 +33,9 @@ import soot.SootMethod;
  */
 public interface CompilerPlugin {
     /**
-     * Returns the plugin's arguments to be parsed from XML or the command line
+     * Returns the plugin's prefix arguments to be parsed from XML or the command line
      */
-    List<CompilerPluginArgument> getArguments();
+    CompilerPluginArguments getArguments();
 
     /**
      * Called just before a class is about to be compiled. Modifications to the 

--- a/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPluginArguments.java
+++ b/compiler/src/main/java/org/robovm/compiler/plugin/CompilerPluginArguments.java
@@ -1,0 +1,26 @@
+package org.robovm.compiler.plugin;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stores the {@link CompilerPluginArgument} along with the prefix to be used
+ * for the arguments.
+ */
+public class CompilerPluginArguments {
+    private final String prefix;
+    private final List<CompilerPluginArgument> arguments;
+
+    public CompilerPluginArguments(String prefix, List<CompilerPluginArgument> arguments) {
+        this.prefix = Objects.requireNonNull(prefix, "Prefix must not be null");
+        this.arguments = Objects.requireNonNull(arguments, "arguments must not be null");
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public List<CompilerPluginArgument> getArguments() {
+        return arguments;
+    }
+}


### PR DESCRIPTION
Plugins now also have to declare a prefix that's prepended to any of their arguments on the CLI. The plugin itself is then responsible for properly parsing the argument.
