### PR TITLE
Continue loop in SigningIdentity

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/SigningIdentity.java
@@ -69,6 +69,8 @@ public class SigningIdentity implements Comparable<SigningIdentity> {
     
     protected static List<SigningIdentity> parse(String securityOutput) {
         /* Output from security looks like this:
+         *   [... ommitted output ...]
+         *   Valid identities only
          *   1) 433D4A1CD97F77226F67959905A2840265A92D31 "iPhone Developer: Rolf Hudson (HS5OW37HQP)" (CSSMERR_TP_CERT_REVOKED)
          *   2) F8E60167BD74A2E9FC39B239E58CCD73BE1112E6 "iPhone Developer: Rolf Hudson (HS5OW37HQP)"
          *   3) AC2EC9D4D26889649DE4196FBFD54BF5924169F9 "iPhone Distribution: Acme Inc"
@@ -80,7 +82,7 @@ public class SigningIdentity implements Comparable<SigningIdentity> {
             line = line.trim();
             Matcher matcher = pattern.matcher(line);
             if (!matcher.find()) {
-                break;
+                continue;
             }
             String name = matcher.group(2);
             String fingerprint = matcher.group(1);


### PR DESCRIPTION
Operating System: Mac OS X 10.9+

I tried using command line to compile my robovm project, but it threw a fatal error during compilation, stating that "No signing identity found matching 'iPhone Developer'". Upon further investigation, I discovered that the expected command line output of the program differed from the actual output; the actual output contains lines before it stating "Valid identities only", etc, that did not match the Pattern's regex, causing the for loop to break. To fix the problem, I tried changing the break statement in the for loop to a continue statement to allow the input to real each line, even after encountering a line that did not match the the Pattern's regex. This causes the loop to continue searching through the entire terminal output. Doing this allows the robovm project to compile properly.

Solution:
If the matcher cannot find the pattern in the given line, continue the loop to search for more lines instead of breaking, as some console outputs include other lines at the beginning, which causes the loop to break, unable to find any Valid identities. Tested on Mac OS X.