### PR TITLE
Proposal for debug hook

### DIFF
--- a/vm/core/src/CMakeLists.txt
+++ b/vm/core/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRC
   proxy0-${OS_FAMILY}-${ARCH}.s
   trycatch-${OS_FAMILY}-${ARCH}.s
   unwind.c
+  debug_hooks.c
 )
 
 # The code in unwind.c doesn't work properly if compiled with tail call optimizations

--- a/vm/core/src/debug_hooks.c
+++ b/vm/core/src/debug_hooks.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 Trillian Mobile AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <robovm.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define LOG_TAG "debug.hooks"
+jboolean attachFlag = FALSE;
+
+void debugHookWaitForAttach(void) {
+    int i = 0;
+    while(attachFlag == FALSE && (i++) < 15) {
+        sleep(1);
+        fprintf(stderr, "[DEBUG] %s: Waiting for debugger to attach\n", LOG_TAG);
+    }
+}
+
+void debugHookBeforeThreads(void) {
+    fprintf(stderr, "[DEBUG] %s: Before thread initialization\n", LOG_TAG);
+}
+
+void debugHookMain(void) {
+    fprintf(stderr, "[DEBUG] %s: VM Initialized, waiting for debugger to resume process\n", LOG_TAG);
+}
+
+void debugHookThreadAttach(JavaThread* threadObj, Thread* thread) {
+    fprintf(stderr, "[DEBUG] %s: Thread attached\n", LOG_TAG);
+}
+
+void debugHookThreadStart(JavaThread* threadObj, Thread* thread) {
+    fprintf(stderr, "[DEBUG] %s: Thread started\n", LOG_TAG);
+}
+
+void debugHookThreadDetach(JavaThread* threadObj, Thread* thread) {
+    fprintf(stderr, "[DEBUG] %s: Thread detached\n", LOG_TAG);
+}


### PR DESCRIPTION
I quickly implemented the required debug hooks:
- debug_hooks.c contains all functions that we require at the moment
- init.c and thread.c call into those hooks in appropriate places
- a corresponding branch named `hooks` in the debug project let's you test the changes. It already uses the new hook locations in `debug_hooks.c`

TODOs
- the hooks are currently forward declared in `init.c` and `thread.c`, i couldn't get weak linking ala `registerDarwinExceptionHandler` working. Clang always links against the weak versions of the hooks even when linking to librobovm-debug.a. So, at the moment the methods are always linked in.
- Moving `debug_hooks.c` to `vm/debug` requires us to always set the `skipInstall` flag on the `Config` so `librobovm-debug.a` gets linked. Maybe we should put it in a new static lib that gets added if `Config#debug` is true? `debug_hooks.c` is currently in `vm/core` where it doesn't belong.
- `debug_hooks.c` needs to be compiled with debug info even if the resulting static lib was build in release mode.
- Apart from `debugHookWaitForAttach`, all hooks simply log to `stderr`, maybe you want them to do something else on which we can break.
