### PR TITLE
Use OSAtomicCompareAndSwap32 for @atomic_cas on iOS ARM

### DIFF
--- a/compiler/src/main/resources/header-darwin-thumbv7.ll
+++ b/compiler/src/main/resources/header-darwin-thumbv7.ll
@@ -24,3 +24,10 @@ define private float @frem(%Env* %env, float %op1, float %op2) alwaysinline {
     %result = fptrunc double %dresult to float
     ret float %result
 }
+
+declare i1 @OSAtomicCompareAndSwap32(i32 %old, i32 %new, i32* %ptr)
+
+define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {  
+  %1 = call i1 @OSAtomicCompareAndSwap32(i32 %old, i32 %new, i32* %ptr)  
+  ret i1 %1
+}

--- a/compiler/src/main/resources/header-darwin-x86.ll
+++ b/compiler/src/main/resources/header-darwin-x86.ll
@@ -15,3 +15,9 @@ define private float @frem(%Env* %env, float %op1, float %op2) alwaysinline {
     %result = frem float %op1, %op2
     ret float %result
 }
+
+define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {
+  %1 = cmpxchg i32* %ptr, i32 %old, i32 %new seq_cst
+  %2 = icmp eq i32 %1, %old
+  ret i1 %2
+}

--- a/compiler/src/main/resources/header-darwin-x86_64.ll
+++ b/compiler/src/main/resources/header-darwin-x86_64.ll
@@ -15,3 +15,9 @@ define private float @frem(%Env* %env, float %op1, float %op2) alwaysinline {
     %result = frem float %op1, %op2
     ret float %result
 }
+
+define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {
+  %1 = cmpxchg i32* %ptr, i32 %old, i32 %new seq_cst
+  %2 = icmp eq i32 %1, %old
+  ret i1 %2
+}

--- a/compiler/src/main/resources/header-linux-x86.ll
+++ b/compiler/src/main/resources/header-linux-x86.ll
@@ -15,3 +15,9 @@ define private float @frem(%Env* %env, float %op1, float %op2) alwaysinline {
     %result = frem float %op1, %op2
     ret float %result
 }
+
+define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {
+  %1 = cmpxchg i32* %ptr, i32 %old, i32 %new seq_cst
+  %2 = icmp eq i32 %1, %old
+  ret i1 %2
+}

--- a/compiler/src/main/resources/header-linux-x86_64.ll
+++ b/compiler/src/main/resources/header-linux-x86_64.ll
@@ -15,3 +15,9 @@ define private float @frem(%Env* %env, float %op1, float %op2) alwaysinline {
     %result = frem float %op1, %op2
     ret float %result
 }
+
+define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {
+  %1 = cmpxchg i32* %ptr, i32 %old, i32 %new seq_cst
+  %2 = icmp eq i32 %1, %old
+  ret i1 %2
+}

--- a/compiler/src/main/resources/header.ll
+++ b/compiler/src/main/resources/header.ll
@@ -884,12 +884,6 @@ false:
     ret i32 0
 }
 
-define private i1 @atomic_cas(i32 %old, i32 %new, i32* %ptr) alwaysinline {
-  %1 = cmpxchg i32* %ptr, i32 %old, i32 %new seq_cst
-  %2 = icmp eq i32 %1, %old
-  ret i1 %2
-}
-
 define private void @monitorenter(%Env* %env, %Object* %o) alwaysinline {
     ; Try the common case first before we call _bcMonitorEnter
     %thin = call i32 @Object_lock(%Object* %o)


### PR DESCRIPTION
Using the intrinsic will trip up LLDB in an infinite loop.
