### PR TITLE
Fixes finalization error when current thread isn't fully initialized

### DIFF
--- a/vm/core/include/robovm/thread.h
+++ b/vm/core/include/robovm/thread.h
@@ -60,6 +60,7 @@ extern Thread* rvmGetThreadByThreadId(Env* env, uint32_t threadId);
 extern jint rvmChangeThreadStatus(Env* env, Thread* thread, jint newStatus);
 extern void rvmChangeThreadPriority(Env* env, Thread* thread, jint priority);
 extern void rvmThreadNameChanged(Env* env, Thread* thread);
+extern jboolean rvmHasCurrentThread(Env* env);
 
 #endif
 

--- a/vm/core/src/memory.c
+++ b/vm/core/src/memory.c
@@ -774,7 +774,7 @@ static void _finalizeObject(GC_PTR addr, GC_PTR client_data) {
     // When attaching a thread (except the main thread) there's a slight chance that the call to rvmCreateEnv()
     // first triggers a GC. If there are finalize objects this function will be called with no Env associated 
     // with the current thread. In such cases we reregister the object for finalization and it will be finalized later.
-    if (env) {
+    if (rvmHasCurrentThread(env)) {
         finalizeObject(env, obj);
     } else {
         GC_REGISTER_FINALIZER_NO_ORDER(obj, _finalizeObject, NULL, NULL, NULL);


### PR DESCRIPTION
Closes #649. During finalization `rvmHasCurrentThread()` is invoked to check if both an `Env` and a `Thread` are available. The `Env` and `Thread` are stored in TLS in `attachThread()`. The thread TLS is set after the thread has been fully initialized. The TLSs are cleared in `detachThread()`.

Tested with a plain libGDX 1.5 app which invokes CoreMotion. App used to crash after at most 2 minutes. Test run with the fix didn't crash for 15 minutes. Note that this may be an insufficient test.
