### PR TITLE
Write PID to a file instead of stderr

### DIFF
--- a/vm/core/include/robovm/types.h
+++ b/vm/core/include/robovm/types.h
@@ -371,6 +371,7 @@ typedef struct Options {
     jboolean enableHooks;
     jboolean waitForAttach;
     jboolean printPID;
+    char* pidFile;
     char basePath[PATH_MAX];
     char executablePath[PATH_MAX];
     char** rawBootclasspath; 

--- a/vm/core/src/init.c
+++ b/vm/core/src/init.c
@@ -146,6 +146,12 @@ static void parseArg(char* arg, Options* options) {
     } else if (startsWith(arg, "WaitForAttach")) {
         options->waitForAttach = TRUE;
         options->enableHooks = TRUE; // WaitForAttach also enables hooks
+    } else if (startsWith(arg, "PrintPID=")) {
+        options->printPID = TRUE;
+        if (!options->pidFile) {
+            char* s = strdup(&arg[9]);
+            options->pidFile = s;
+        }
     } else if (startsWith(arg, "PrintPID")) {
         options->printPID = TRUE;
     } else if (startsWith(arg, "D")) {
@@ -254,7 +260,14 @@ Env* rvmStartup(Options* options) {
     // print PID if it was requested
     if(options->printPID) {
         pid_t pid = getpid();
-        fprintf(stderr, "[DEBUG] %s: pid=%d\n", LOG_TAG, pid);
+        if(options->pidFile) {
+            FILE* f = fopen(options->pidFile, "w");
+            if (!f) return NULL;
+            fprintf(f, "%d", pid);
+            fclose(f);
+        } else {
+            fprintf(stderr, "[DEBUG] %s: pid=%d\n", LOG_TAG, pid);
+        }
     }
 
     if(options->waitForAttach) {


### PR DESCRIPTION
Added `-rvm:PrintPID=<pidfilename>` which will let the app write its PID to the specified file. The old behaviour of `-rvm:PrintPID` writting the PID to stderr still works if the `=<pidfilename` part is omitted.

You'll need to rebuild the binaries obviously.
