### PR TITLE
Disable PIE/PIC in debug mode

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
+++ b/compiler/src/main/java/org/robovm/compiler/ClassCompiler.java
@@ -341,7 +341,7 @@ public class ClassCompiler {
                     targetMachine.setFunctionSections(true);
                     targetMachine.setDataSections(true);
                     targetMachine.getOptions().setNoFramePointerElim(true);
-                    targetMachine.getOptions().setPositionIndependentExecutable(true); // NOTE: Doesn't have any effect on x86. See #503.
+                    targetMachine.getOptions().setPositionIndependentExecutable(!config.isDebug()); // NOTE: Doesn't have any effect on x86. See #503.
 
                     ByteArrayOutputStream output = new ByteArrayOutputStream(256 * 1024);
                     targetMachine.emit(module, output, CodeGenFileType.AssemblyFile);

--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -269,6 +269,9 @@ public class IOSTarget extends AbstractTarget {
 
         if (isDeviceArch(arch)) {
             ccArgs.add("-miphoneos-version-min=" + config.getOs().getMinVersion());
+            if (config.isDebug()) {
+                ccArgs.add("-Wl,-no_pie");
+            }
         } else {
             ccArgs.add("-mios-simulator-version-min=" + config.getOs().getMinVersion());
             if (config.getArch() == Arch.x86) {


### PR DESCRIPTION
Disabling PIE/PIC is required so that iOS on the device doesn't apply [ASLR](http://en.wikipedia.org/wiki/Address_space_layout_randomization). Otherwise addresses as found in the sections of an executable do not match up to the addresses within a loaded process. To disble ASLR, we need to use `-no_pie` for linking.

Tested against console, sim & device, 32-bit and 64-bit (device crashes debugger eventually as before).