### PR TITLE
UIViews should be strongly referenced when added to other UIViews

### DIFF
--- a/cocoatouch/src/main/bro-gen/uikit.yaml
+++ b/cocoatouch/src/main/bro-gen/uikit.yaml
@@ -2728,10 +2728,6 @@ classes:
                 name: convertRectFromView
             '-convertRect:toView:':
                 name: convertRectToView
-            '-insertSubview:aboveSubview:':
-                name: insertSubviewAbove
-            '-insertSubview:belowSubview:':
-                name: insertSubviewBelow
             '-isDescendantOfView:':
                 name: isDescendantOf
             '-drawRect:':
@@ -2783,10 +2779,21 @@ classes:
                 trim_after_first_colon: true
             '-pointInside:withEvent:':
                 name: isPointInside
+            '-removeFromSuperview':
+                name: removeFromSuperview0
+                visibility: private # strong reference
             '-insertSubview:atIndex:':
-                trim_after_first_colon: true
+                name: insertSubview0
+                visibility: private # strong reference
             '-addSubview:':
-                trim_after_first_colon: true
+                name: addSubview0
+                visibility: private # strong reference
+            '-insertSubview:aboveSubview:':
+                name: insertSubviewAbove0
+                visibility: private # strong reference
+            '-insertSubview:belowSubview:':
+                name: insertSubviewBelow0
+                visibility: private # strong reference
             '-bringSubviewToFront:':
                 trim_after_first_colon: true
             '-sendSubviewToBack:':

--- a/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/uikit/UIView.java
@@ -248,6 +248,32 @@ import org.robovm.apple.corelocation.*;
     public native void setAccessibilityIdentifier(String v);
     /*</properties>*/
     /*<members>*//*</members>*/
+    
+    /* GC save methods for adding and removing views. */
+    public void removeFromSuperview() {
+        UIView parent = getSuperview();
+        if (parent != null) {
+            parent.removeStrongRef(this);
+        }
+        removeFromSuperview0();
+    }
+    public void insertSubview(UIView view, @MachineSizedSInt long index) {
+        insertSubview0(view, index);
+        addStrongRef(view);
+    }
+    public void addSubview(UIView view) {
+        addSubview0(view);
+        addStrongRef(view);
+    }
+    public void insertSubviewBelow(UIView view, UIView siblingSubview) {
+        insertSubviewBelow0(view, siblingSubview);
+        addStrongRef(view);
+    }
+    public void insertSubviewAbove(UIView view, UIView siblingSubview) {
+        insertSubviewAbove0(view, siblingSubview);
+        addStrongRef(view);
+    }
+    
     /*<methods>*/
     /**
      * @since Available in iOS 6.0 and later.
@@ -276,17 +302,17 @@ import org.robovm.apple.corelocation.*;
     @Method(selector = "sizeToFit")
     public native void sizeToFit();
     @Method(selector = "removeFromSuperview")
-    public native void removeFromSuperview();
+    private native void removeFromSuperview0();
     @Method(selector = "insertSubview:atIndex:")
-    public native void insertSubview(UIView view, @MachineSizedSInt long index);
+    private native void insertSubview0(UIView view, @MachineSizedSInt long index);
     @Method(selector = "exchangeSubviewAtIndex:withSubviewAtIndex:")
     public native void exchangeSubview(@MachineSizedSInt long index1, @MachineSizedSInt long index2);
     @Method(selector = "addSubview:")
-    public native void addSubview(UIView view);
+    private native void addSubview0(UIView view);
     @Method(selector = "insertSubview:belowSubview:")
-    public native void insertSubviewBelow(UIView view, UIView siblingSubview);
+    private native void insertSubviewBelow0(UIView view, UIView siblingSubview);
     @Method(selector = "insertSubview:aboveSubview:")
-    public native void insertSubviewAbove(UIView view, UIView siblingSubview);
+    private native void insertSubviewAbove0(UIView view, UIView siblingSubview);
     @Method(selector = "bringSubviewToFront:")
     public native void bringSubviewToFront(UIView view);
     @Method(selector = "sendSubviewToBack:")

--- a/cocoatouch/src/test/java/org/robovm/apple/uikit/CustomUIViewTest.java
+++ b/cocoatouch/src/test/java/org/robovm/apple/uikit/CustomUIViewTest.java
@@ -1,0 +1,92 @@
+package org.robovm.apple.uikit;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robovm.apple.coregraphics.CGRect;
+import org.robovm.apple.foundation.NSArray;
+
+public class CustomUIViewTest {
+    private static final String STRONG_REFS_KEY = "org.robovm.objc.ObjCObject$AssociatedObjectHelper.StrongRefs";
+    private static final String TEST_STRING_VALUE = "TEST";
+    private static final long TEST_LONG_VALUE = 1234567890L;
+    private static final int TEST_COUNT = 50;
+    private UIView parentView;
+    private UIViewController viewController;
+    
+    private class CustomUIView extends UIView {
+        public String stringVar;
+        public long longVar;
+        
+        public CustomUIView(String stringVar, long longVar) {
+            super(new CGRect());
+            this.stringVar = stringVar;
+            this.longVar = longVar;
+        }
+    }
+    
+    @Before
+    public void setup() {
+        parentView = new UIView();
+        viewController = new UIViewController();
+        for (int i = 0; i < TEST_COUNT; i++) {
+            CustomUIView customView = new CustomUIView(TEST_STRING_VALUE, TEST_LONG_VALUE);
+            parentView.addSubview(customView);
+            CustomUIView customView2 = new CustomUIView(TEST_STRING_VALUE, TEST_LONG_VALUE);
+            viewController.getView().addSubview(customView2);
+        }
+        // Force GC.
+        for (int i = 0; i < 5; i++) {
+            System.gc();
+        }
+    }
+    
+    @Test
+    public void testIfCustomUIViewVariablesOfParentViewAreRetained() {
+        NSArray<UIView> subviews = parentView.getSubviews();
+        for (int i = 0; i < TEST_COUNT; i++) {
+            CustomUIView customView = (CustomUIView)subviews.get(i);
+            assertEquals(TEST_LONG_VALUE, customView.longVar);
+            assertEquals(TEST_STRING_VALUE, customView.stringVar);
+        }
+    }
+    
+    @Test
+    public void testIfRemovedSubviewsOfParentViewAreNotRetained() {
+        List associatedObjects = (List)parentView.getAssociatedObject(STRONG_REFS_KEY);
+        assertEquals("Strong references have been lost unexpectedly!", TEST_COUNT, associatedObjects.size());
+        NSArray<UIView> subviews = parentView.getSubviews();
+        for (int i = 0; i < TEST_COUNT; i++) {
+            CustomUIView customView = (CustomUIView)subviews.get(i);
+            customView.removeFromSuperview();
+        }
+        associatedObjects = (List)parentView.getAssociatedObject(STRONG_REFS_KEY);
+        assertEquals(null, associatedObjects);
+    }
+    
+    @Test
+    public void testIfCustomUIViewVariablesOfViewControllerAreRetained() {
+        NSArray<UIView> subviews = viewController.getView().getSubviews();
+        for (int i = 0; i < TEST_COUNT; i++) {
+            CustomUIView customView = (CustomUIView)subviews.get(i);
+            assertEquals(TEST_LONG_VALUE, customView.longVar);
+            assertEquals(TEST_STRING_VALUE, customView.stringVar);
+        }
+    }
+    
+    @Test
+    public void testIfRemovedSubviewsOfViewControllerAreNotRetained() {
+        List associatedObjects = (List)viewController.getView().getAssociatedObject(STRONG_REFS_KEY);
+        assertEquals("Strong references have been lost unexpectedly!", TEST_COUNT, associatedObjects.size());
+        NSArray<UIView> subviews = viewController.getView().getSubviews();
+        for (int i = 0; i < TEST_COUNT; i++) {
+            CustomUIView customView = (CustomUIView)subviews.get(i);
+            customView.removeFromSuperview();
+        }
+        associatedObjects = (List)viewController.getView().getAssociatedObject(STRONG_REFS_KEY);
+        assertEquals(null, associatedObjects);
+    }
+}


### PR DESCRIPTION
This PR addresses issue #708 which is really common but hard to debug. With this fix UIViews will get attached (strongly referenced) to their parent view when they are added or inserted, as well get dereferenced as soon as the views are removed from their parent. This effectively prevents the views from being GCed too early. 