### PR TITLE
Use a separate lock for peers lookup to resolve deadlock in finalization

### DIFF
--- a/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -48,6 +48,8 @@ import org.robovm.rt.bro.ptr.VoidPtr;
   @Marshaler(ObjCClass.Marshaler.class)
 })
 public abstract class ObjCObject extends NativeObject {
+    
+    private static final Object peerLock = new Object();
 
     public static class ObjCObjectPtr extends Ptr<ObjCObject, ObjCObjectPtr> {}
     
@@ -164,10 +166,10 @@ public abstract class ObjCObject extends NativeObject {
     public final ObjCClass getObjCClass() {
         return ObjCClass.getFromObject(this);
     }
-    
+
     @SuppressWarnings("unchecked")
     static <T extends ObjCObject> T getPeerObject(long handle) {
-        synchronized (objcBridgeLock) {
+        synchronized (peerLock) {
             ObjCObjectRef ref = peers.get(handle);
             T o = ref != null ? (T) ref.get() : null;
             return o;
@@ -175,7 +177,7 @@ public abstract class ObjCObject extends NativeObject {
     }
     
     private static void setPeerObject(long handle, ObjCObject o) {
-        synchronized (objcBridgeLock) {
+        synchronized (peerLock) {
             if (o == null) {
                 peers.remove(handle);
             } else {
@@ -186,7 +188,7 @@ public abstract class ObjCObject extends NativeObject {
 
     
     private static void removePeerObject(ObjCObject o) {
-        synchronized (objcBridgeLock) {
+        synchronized (peerLock) {
             ObjCObjectRef ref = peers.remove(o.getHandle());
             ObjCObject p = ref != null ? ref.get() : null;
             if (p != null && o != p) {


### PR DESCRIPTION
I get a timeout in the finalizer watchdog, see https://github.com/robovm/robovm-debug/issues/301 It can be traced back to the `objcBridgeLock` used to guard the `peers` lookup in `ObjCObject` against current reads/writes.

Using a separate lock resolves the issue, indicating that there was (still is?) a deadlock somewhere in the use `objcBridgeLock`.