### PR TITLE
Temporary fix for issue #772

### DIFF
--- a/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/foundation/NSObject.java
@@ -211,9 +211,9 @@ import org.robovm.apple.dispatch.*;
     @Method(selector = "respondsToSelector:")
     public native boolean respondsToSelector(Selector aSelector);
     @Method(selector = "retain")
-    public native NSObject retain();
+    public final native NSObject retain();
     @Method(selector = "release")
-    public native void release();
+    public final native void release();
     @Method(selector = "autorelease")
     public native NSObject autorelease();
     @Method(selector = "retainCount")

--- a/objc/src/main/java/org/robovm/objc/ObjCClass.java
+++ b/objc/src/main/java/org/robovm/objc/ObjCClass.java
@@ -295,7 +295,13 @@ public final class ObjCClass extends ObjCObject {
             }
         }
         ObjCRuntime.objc_registerClassPair(handle);
-        return new ObjCClass(handle, type, name, true);
+        
+        ObjCClass objcClass = new ObjCClass(handle, type, name, true);
+        if (objcClass.custom) {
+            ObjCObject.ObjectOwnershipHelper.registerClass(objcClass);
+        }
+        
+        return objcClass;
     }
     
     private static Map<String, Method> getCallbacks(Class<?> type) {

--- a/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -44,27 +44,29 @@ import org.robovm.rt.bro.ptr.VoidPtr;
 @Library("Foundation")
 @NativeClass("Object")
 @Marshalers({
-  @Marshaler(ObjCObject.Marshaler.class),
-  @Marshaler(ObjCClass.Marshaler.class)
+    @Marshaler(ObjCObject.Marshaler.class),
+    @Marshaler(ObjCClass.Marshaler.class)
 })
 public abstract class ObjCObject extends NativeObject {
 
     public static class ObjCObjectPtr extends Ptr<ObjCObject, ObjCObjectPtr> {}
-    
+
     static {
         ObjCRuntime.bind();
-        
+
         try {
             Field f = ObjCObject.class.getDeclaredField("customClass");
             CUSTOM_CLASS_OFFSET = VM.getInstanceFieldOffset(VM.getFieldAddress(f));
         } catch (Throwable t) {
             throw new Error(t);
         }
+
+        NS_OBJECT_CLASS = ObjCRuntime.objc_getClass(VM.getStringUTFChars("NSObject"));
     }
 
     /**
-     * Common lock object used to prevent concurrent access to data in the
-     * Obj-C bridge (such as {@link ObjCObject#peers} and 
+     * Common lock object used to prevent concurrent access to data in the Obj-C
+     * bridge (such as {@link ObjCObject#peers} and
      * {@link ObjCClass#typeToClass}). This should be used to prevent deadlock
      * situations from occurring. (#349)
      */
@@ -73,10 +75,11 @@ public abstract class ObjCObject extends NativeObject {
     private static final LongMap<ObjCObjectRef> peers = new LongMap<>();
 
     private static final long CUSTOM_CLASS_OFFSET;
-    
+    private static final long NS_OBJECT_CLASS;
+
     private ObjCSuper zuper;
     protected final boolean customClass;
-    
+
     protected ObjCObject() {
         long handle = alloc();
         setHandle(handle);
@@ -87,17 +90,17 @@ public abstract class ObjCObject extends NativeObject {
         }
         customClass = getObjCClass().isCustom();
     }
-    
+
     protected ObjCObject(long handle) {
         initObject(handle);
         customClass = getObjCClass().isCustom();
     }
-    
+
     ObjCObject(long handle, boolean customClass) {
         initObject(handle);
         this.customClass = customClass;
     }
-    
+
     protected void initObject(long handle) {
         if (handle == 0) {
             throw new RuntimeException("Objective-C initialization method returned nil");
@@ -111,23 +114,22 @@ public abstract class ObjCObject extends NativeObject {
             setPeerObject(handle, this);
         }
     }
-    
+
     protected long alloc() {
         throw new UnsupportedOperationException("Cannot create instances of " + getClass().getName());
     }
-    
+
     @Override
     protected final void finalize() throws Throwable {
         dispose(true);
     }
-    
+
     public final void dispose() {
         dispose(false);
     }
-    
-    protected void doDispose() {
-    }
-    
+
+    protected void doDispose() {}
+
     protected void dispose(boolean finalizing) {
         long handle = getHandle();
         if (handle != 0) {
@@ -143,7 +145,7 @@ public abstract class ObjCObject extends NativeObject {
             }
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     protected ObjCSuper getSuper() {
         if (zuper == null) {
@@ -157,14 +159,13 @@ public abstract class ObjCObject extends NativeObject {
         }
         return zuper;
     }
-    
-    protected void afterMarshaled() {
-    }
-    
+
+    protected void afterMarshaled() {}
+
     public final ObjCClass getObjCClass() {
         return ObjCClass.getFromObject(this);
     }
-    
+
     @SuppressWarnings("unchecked")
     static <T extends ObjCObject> T getPeerObject(long handle) {
         synchronized (objcBridgeLock) {
@@ -173,7 +174,7 @@ public abstract class ObjCObject extends NativeObject {
             return o;
         }
     }
-    
+
     private static void setPeerObject(long handle, ObjCObject o) {
         synchronized (objcBridgeLock) {
             if (o == null) {
@@ -184,7 +185,6 @@ public abstract class ObjCObject extends NativeObject {
         }
     }
 
-    
     private static void removePeerObject(ObjCObject o) {
         synchronized (objcBridgeLock) {
             ObjCObjectRef ref = peers.remove(o.getHandle());
@@ -195,32 +195,32 @@ public abstract class ObjCObject extends NativeObject {
             }
         }
     }
-    
+
     public <T extends Object> T addStrongRef(T to) {
         AssociatedObjectHelper.addStrongRef(this, to);
         return to;
     }
-    
+
     public void removeStrongRef(Object to) {
         AssociatedObjectHelper.removeStrongRef(this, to, false);
     }
-    
+
     /**
-     * Updates a strong reference handling {@code null} values properly. This
-     * is meant to be used for {@link Property} setter methods with 
+     * Updates a strong reference handling {@code null} values properly. This is
+     * meant to be used for {@link Property} setter methods with
      * {@code strongRef=true}.
      * 
      * @param before the previous value for the property. If not {@code null}
-     *        and not equal to {@code after} {@link #removeStrongRef(Object)}
-     *        will be called on this value.
-     * @param after the new value for the property. If not {@code null}
-     *        and not equal to {@code after} {@link #addStrongRef(Object)}
-     *        will be called on this value.
+     *            and not equal to {@code after}
+     *            {@link #removeStrongRef(Object)} will be called on this value.
+     * @param after the new value for the property. If not {@code null} and not
+     *            equal to {@code after} {@link #addStrongRef(Object)} will be
+     *            called on this value.
      */
     public void updateStrongRef(Object before, Object after) {
         if (before == after) {
             // Either both are null or they reference the same object.
-            // If not null we assume that the property has already been set so 
+            // If not null we assume that the property has already been set so
             // that there already exists a strong reference.
             return;
         }
@@ -233,7 +233,7 @@ public abstract class ObjCObject extends NativeObject {
             AssociatedObjectHelper.addStrongRef(this, after);
         }
     }
-    
+
     public Object getAssociatedObject(Object key) {
         return AssociatedObjectHelper.getAssociatedObject(this, key);
     }
@@ -241,11 +241,11 @@ public abstract class ObjCObject extends NativeObject {
     public void setAssociatedObject(Object key, Object value) {
         AssociatedObjectHelper.setAssociatedObject(this, key, value);
     }
-    
+
     public static <T extends ObjCObject> T toObjCObject(Class<T> cls, long handle) {
         return toObjCObject(cls, handle, false);
     }
-    
+
     @SuppressWarnings("unchecked")
     public static <T extends ObjCObject> T toObjCObject(Class<T> cls, long handle, boolean forceType) {
         if (handle == 0L) {
@@ -259,15 +259,15 @@ public abstract class ObjCObject extends NativeObject {
             T o = getPeerObject(handle);
             if (o != null && o.getHandle() != 0) {
                 if (forceType && !cls.isAssignableFrom(o.getClass())) {
-                    throw new IllegalStateException("The peer object type " + o.getClass().getName() 
+                    throw new IllegalStateException("The peer object type " + o.getClass().getName()
                             + " is not compatible with the forced type " + cls.getName());
                 }
                 return o;
             }
-    
+
             ObjCClass objCClass = forceType ? ObjCClass.getByType(cls) : ObjCClass.getFromObject(handle);
             Class<T> c = (Class<T>) objCClass.getType();
-    
+
             o = VM.allocateObject(c);
             o.setHandle(handle);
             setPeerObject(handle, o);
@@ -278,13 +278,14 @@ public abstract class ObjCObject extends NativeObject {
             return o;
         }
     }
-    
+
     public static class Marshaler {
         @MarshalsPointer
         public static ObjCObject toObject(Class<? extends ObjCObject> cls, long handle, long flags) {
             ObjCObject o = ObjCObject.toObjCObject(cls, handle);
             return o;
         }
+
         @MarshalsPointer
         public static long toNative(ObjCObject o, long flags) {
             if (o == null) {
@@ -292,6 +293,7 @@ public abstract class ObjCObject extends NativeObject {
             }
             return o.getHandle();
         }
+
         @MarshalsPointer
         public static ObjCProtocol protocolToObject(Class<?> cls, long handle, long flags) {
             Class<? extends ObjCObject> proxyClass = ObjCClass.allObjCProxyClasses.get(cls.getName());
@@ -301,6 +303,7 @@ public abstract class ObjCObject extends NativeObject {
             ObjCObject o = ObjCObject.toObjCObject(proxyClass, handle);
             return (ObjCProtocol) o;
         }
+
         @MarshalsPointer
         public static long protocolToNative(ObjCProtocol o, long flags) {
             if (o == null) {
@@ -309,20 +312,85 @@ public abstract class ObjCObject extends NativeObject {
             return ((ObjCObject) o).getHandle();
         }
     }
-    
+
     static class ObjCObjectRef extends WeakReference<ObjCObject> {
         public final long handle;
+
         public ObjCObjectRef(ObjCObject referent) {
             super(referent);
             handle = referent.getHandle();
         }
     }
-    
+
+    static class ObjectOwnershipHelper {
+        private static final LongMap<Object> CUSTOM_OBJECTS = new LongMap<>();
+
+        private static final long retainCount = Selector.register("retainCount").getHandle();
+        private static final long retain = Selector.register("retain").getHandle();
+        private static final long originalRetain = Selector.register("original_retain").getHandle();
+        private static final long release = Selector.register("release").getHandle();
+        private static final long originalRelease = Selector.register("original_release").getHandle();
+
+        private static final Method retainMethod;
+        private static final Method releaseMethod;
+
+        static {
+            try {
+                retainMethod = ObjectOwnershipHelper.class.getDeclaredMethod("retain", ObjCObject.class, Long.TYPE);
+                releaseMethod = ObjectOwnershipHelper.class.getDeclaredMethod("release", Long.TYPE, Long.TYPE);
+            } catch (Throwable t) {
+                throw new Error(t);
+            }
+        }
+
+        public static void registerClass(ObjCClass objCClass) {
+            registerCallbackMethod(objCClass.getHandle(), retain, originalRetain, retainMethod);
+            registerCallbackMethod(objCClass.getHandle(), release, originalRelease, releaseMethod);
+        }
+
+        private static void registerCallbackMethod(long cls, long selector, long newSelector, Method method) {
+            long superMethod = ObjCRuntime.class_getInstanceMethod(cls, selector);
+            long typeEncoding = ObjCRuntime.method_getTypeEncoding(superMethod);
+
+            if (!ObjCRuntime.class_addMethod(cls, selector, VM.getCallbackMethodImpl(method), typeEncoding)) {
+                throw new Error(
+                        "Failed to register callback method on the ObjectOwnershipHelper: class_addMethod(...) failed");
+            }
+            ObjCRuntime.class_replaceMethod(cls, newSelector, ObjCRuntime.method_getImplementation(superMethod),
+                    typeEncoding);
+        }
+
+        @Callback
+        private static @Pointer long retain(ObjCObject self, @Pointer long sel) {
+            if (ObjCRuntime.int_objc_msgSend(self.getHandle(), retainCount) <= 1) {
+                synchronized (CUSTOM_OBJECTS) {
+                    CUSTOM_OBJECTS.put(self.getHandle(), self);
+                }
+            }
+            return ObjCRuntime.ptr_objc_msgSendSuper(new Super(self.getHandle(), NS_OBJECT_CLASS).getHandle(), sel);
+        }
+
+        @Callback
+        private static void release(@Pointer long self, @Pointer long sel) {
+            if (ObjCRuntime.int_objc_msgSend(self, retainCount) == 1) {
+                synchronized (CUSTOM_OBJECTS) {
+                    CUSTOM_OBJECTS.remove(self);
+                }
+            }
+            ObjCRuntime.void_objc_msgSendSuper(new Super(self, NS_OBJECT_CLASS).getHandle(), sel);
+        }
+        
+        public static boolean isObjectRetained(ObjCObject object) {
+            synchronized (CUSTOM_OBJECTS) {
+                return CUSTOM_OBJECTS.containsKey(object.getHandle());
+            }
+        }
+    }
+
     static class AssociatedObjectHelper {
         private static final String STRONG_REFS_KEY = AssociatedObjectHelper.class.getName() + ".StrongRefs";
 
         private static final int OBJC_ASSOCIATION_RETAIN_NONATOMIC = 1;
-        private static final long NS_OBJECT_CLASS;
         private static final long RELEASE_LISTENER_CLASS;
         private static final String OWNER_IVAR_NAME = "value";
         private static final int OWNER_IVAR_OFFSET;
@@ -330,19 +398,22 @@ public abstract class ObjCObject extends NativeObject {
         private static final Selector init = Selector.register("init");
         private static final Selector release = Selector.register("release");
         private static final Selector retainCount = Selector.register("retainCount");
-        private static final Map<Long, Map<Object, Object>> ASSOCIATED_OBJECTS = new HashMap<Long, Map<Object, Object>>();
+        private static final LongMap<Map<Object, Object>> ASSOCIATED_OBJECTS = new LongMap<>();
 
         static {
             int ptrSize = VoidPtr.sizeOf();
             int alignment = ptrSize == 4 ? 2 : 3;
-            
-            NS_OBJECT_CLASS = ObjCRuntime.objc_getClass(VM.getStringUTFChars("NSObject"));
-            long cls = ObjCRuntime.objc_allocateClassPair(NS_OBJECT_CLASS, VM.getStringUTFChars("RoboVMReleaseListener"), ptrSize);
+
+            long cls = ObjCRuntime.objc_allocateClassPair(NS_OBJECT_CLASS,
+                    VM.getStringUTFChars("RoboVMReleaseListener"), ptrSize);
             if (cls == 0L) {
-                throw new Error("Failed to create the RoboVMReleaseListener Objective-C class: objc_allocateClassPair(...) failed");
+                throw new Error(
+                        "Failed to create the RoboVMReleaseListener Objective-C class: objc_allocateClassPair(...) failed");
             }
-            if (!ObjCRuntime.class_addIvar(cls, VM.getStringUTFChars(OWNER_IVAR_NAME), ptrSize, (byte) alignment, VM.getStringUTFChars("?"))) {
-                throw new Error("Failed to create the RoboVMAssocObjWrapper Objective-C class: class_addIvar(...) failed");
+            if (!ObjCRuntime.class_addIvar(cls, VM.getStringUTFChars(OWNER_IVAR_NAME), ptrSize, (byte) alignment,
+                    VM.getStringUTFChars("?"))) {
+                throw new Error(
+                        "Failed to create the RoboVMAssocObjWrapper Objective-C class: class_addIvar(...) failed");
             }
             Method releaseMethod = null;
             try {
@@ -352,13 +423,16 @@ public abstract class ObjCObject extends NativeObject {
             }
             long superReleaseMethod = ObjCRuntime.class_getInstanceMethod(NS_OBJECT_CLASS, release.getHandle());
             long releaseType = ObjCRuntime.method_getTypeEncoding(superReleaseMethod);
-            if (!ObjCRuntime.class_addMethod(cls, release.getHandle(), VM.getCallbackMethodImpl(releaseMethod), releaseType)) {
-                throw new Error("Failed to create the RoboVMReleaseListener Objective-C class: class_addMethod(...) failed");                
+            if (!ObjCRuntime.class_addMethod(cls, release.getHandle(), VM.getCallbackMethodImpl(releaseMethod),
+                    releaseType)) {
+                throw new Error(
+                        "Failed to create the RoboVMReleaseListener Objective-C class: class_addMethod(...) failed");
             }
             ObjCRuntime.objc_registerClassPair(cls);
-            
+
             RELEASE_LISTENER_CLASS = cls;
-            OWNER_IVAR_OFFSET = ObjCRuntime.ivar_getOffset(ObjCRuntime.class_getInstanceVariable(cls, VM.getStringUTFChars(OWNER_IVAR_NAME)));
+            OWNER_IVAR_OFFSET = ObjCRuntime.ivar_getOffset(ObjCRuntime.class_getInstanceVariable(cls,
+                    VM.getStringUTFChars(OWNER_IVAR_NAME)));
         }
 
         private static void enableListener(long handle) {
@@ -370,7 +444,8 @@ public abstract class ObjCObject extends NativeObject {
                 }
                 releaseListener = ObjCRuntime.ptr_objc_msgSend(releaseListener, init.getHandle());
                 VM.setPointer(releaseListener + OWNER_IVAR_OFFSET, handle);
-                ObjCRuntime.objc_setAssociatedObject(handle, RELEASE_LISTENER_CLASS, releaseListener, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                ObjCRuntime.objc_setAssociatedObject(handle, RELEASE_LISTENER_CLASS, releaseListener,
+                        OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 ObjCRuntime.void_objc_msgSend(releaseListener, release.getHandle());
             }
         }
@@ -406,7 +481,7 @@ public abstract class ObjCObject extends NativeObject {
                     map.remove(key);
                     if (map.isEmpty()) {
                         disableListener(object.getHandle());
-                        ASSOCIATED_OBJECTS.remove(object.getHandle());                        
+                        ASSOCIATED_OBJECTS.remove(object.getHandle());
                     }
                 }
             }
@@ -435,8 +510,8 @@ public abstract class ObjCObject extends NativeObject {
             synchronized (ASSOCIATED_OBJECTS) {
                 List l = (List) getAssociatedObject(from, STRONG_REFS_KEY);
                 if (!ignoreNotExists && (l == null || !l.remove(to))) {
-                    throw new IllegalArgumentException("No strong ref exists from " + from 
-                            + " (a " + from.getClass().getName() + ") to " + to 
+                    throw new IllegalArgumentException("No strong ref exists from " + from
+                            + " (a " + from.getClass().getName() + ") to " + to
                             + " a (" + to.getClass().getName() + ")");
                 }
                 if (l != null && l.isEmpty()) {
@@ -444,36 +519,36 @@ public abstract class ObjCObject extends NativeObject {
                 }
             }
         }
-        
+
         @Callback
         static void release(@Pointer long self, @Pointer long sel) {
             if (ObjCRuntime.int_objc_msgSend(self, retainCount.getHandle()) == 1) {
                 long owner = VM.getPointer(self + OWNER_IVAR_OFFSET);
                 synchronized (ASSOCIATED_OBJECTS) {
-                    ASSOCIATED_OBJECTS.remove(owner);   
+                    ASSOCIATED_OBJECTS.remove(owner);
                 }
             }
             ObjCRuntime.void_objc_msgSendSuper(new Super(self, NS_OBJECT_CLASS).getHandle(), sel);
         }
-        
-        public static final class Super extends Struct<Super> {
+    }
 
-            public Super(long receiver, long objcClass) {
-                receiver(receiver);
-                objCClass(objcClass);
-            }
-            
-            @StructMember(0)
-            public native @Pointer long receiver();
-            
-            @StructMember(0)
-            public native Super receiver(@Pointer long receiver);
-            
-            @StructMember(1)
-            public native @Pointer long objCClass();
-            
-            @StructMember(1)
-            public native Super objCClass(@Pointer long objCClass);
+    public static final class Super extends Struct<Super> {
+
+        public Super(long receiver, long objcClass) {
+            receiver(receiver);
+            objCClass(objcClass);
         }
+
+        @StructMember(0)
+        public native @Pointer long receiver();
+
+        @StructMember(0)
+        public native Super receiver(@Pointer long receiver);
+
+        @StructMember(1)
+        public native @Pointer long objCClass();
+
+        @StructMember(1)
+        public native Super objCClass(@Pointer long objCClass);
     }
 }

--- a/objc/src/main/java/org/robovm/objc/ObjCRuntime.java
+++ b/objc/src/main/java/org/robovm/objc/ObjCRuntime.java
@@ -180,6 +180,9 @@ public class ObjCRuntime {
     public static native boolean class_addMethod(@Pointer long cls, @Pointer long name, @Pointer long imp, @Pointer long types);
     
     @Bridge
+    public static native @Pointer long class_replaceMethod(@Pointer long cls, @Pointer long name, @Pointer long imp, @Pointer long types);
+    
+    @Bridge
     public static native boolean class_addIvar(@Pointer long cls, @Pointer long name, int size, byte alignment, @Pointer long types);
     
     @Bridge
@@ -196,6 +199,9 @@ public class ObjCRuntime {
     
     @Bridge
     public static native @Pointer long method_getImplementation(@Pointer long method);
+    
+    @Bridge
+    public static native @Pointer long method_setImplementation(@Pointer long m, @Pointer long imp);
     
     @Bridge(symbol = "objc_msgSend")
     public static native @Pointer long ptr_objc_msgSend(@Pointer long receiver, @Pointer long selector);

--- a/tests/robovm/src/test/java/org/robovm/objc/ObjCObjectOwnershipHelperTest.java
+++ b/tests/robovm/src/test/java/org/robovm/objc/ObjCObjectOwnershipHelperTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2013-2015 Trillian Mobile AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.objc;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.robovm.apple.corefoundation.CFString;
+import org.robovm.apple.foundation.NSCache;
+import org.robovm.apple.foundation.NSCacheDelegate;
+import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.uikit.UIView;
+
+public class ObjCObjectOwnershipHelperTest {
+
+    class CustomNSObject extends NSObject {
+        String stringValue;
+        long longValue;
+
+        public CustomNSObject(String stringValue, long longValue) {
+            this.stringValue = stringValue;
+            this.longValue = longValue;
+        }
+    }
+
+    class CustomUIView extends UIView {}
+
+    class CustomNSCacheDelegateAdapter extends NSObject implements NSCacheDelegate {
+        @Override
+        public void willEvictObject(NSCache cache, NSObject obj) {
+
+        }
+    }
+
+    class CustomCFString extends CFString {
+        public CustomCFString(String str) {
+            super(str);
+        }
+    }
+
+    /**
+     * Every custom class extending from NSObject should be retained on the Java
+     * side when retained on the Obj-C side.
+     */
+    @Test
+    public void testIfCustomObjectsAreRetained() {
+        CustomUIView c1 = new CustomUIView();
+        CustomNSCacheDelegateAdapter c2 = new CustomNSCacheDelegateAdapter();
+        CustomCFString c3 = new CustomCFString("");
+
+        NSCache cache = new NSCache();
+        cache.put("1", c1);
+        cache.put("2", c2);
+        cache.put("3", c3.as(NSObject.class));
+
+        assertEquals(true, ObjCObject.ObjectOwnershipHelper.isObjectRetained(c1));
+        assertEquals(true, ObjCObject.ObjectOwnershipHelper.isObjectRetained(c2));
+        assertEquals(false, ObjCObject.ObjectOwnershipHelper.isObjectRetained(c3.as(NSObject.class)));
+    }
+
+    /**
+     * Only custom objects should get the hooks to retain and release.
+     */
+    @Test
+    public void testIfOnlyCustomObjectsAreRetained() {
+        CustomUIView custom = new CustomUIView();
+        NSObject default1 = new NSObject();
+        UIView default2 = new UIView();
+
+        NSCache cache = new NSCache();
+        cache.put("1", custom);
+        cache.put("2", default1);
+        cache.put("3", default2);
+
+        assertEquals(true, ObjCObject.ObjectOwnershipHelper.isObjectRetained(custom));
+        assertEquals(false, ObjCObject.ObjectOwnershipHelper.isObjectRetained(default1));
+        assertEquals(false, ObjCObject.ObjectOwnershipHelper.isObjectRetained(default2));
+    }
+
+    private void addNewCustomObjectToCache(NSCache cache, String id, String stringValue, long longValue) {
+        cache.put(id, new CustomNSObject(stringValue, longValue));
+    }
+    
+    /**
+     * Every retained object should not be GCed and lose the values of its variables.
+     */
+    @Test
+    public void testIfCustomObjectsVariablesAreRetained() {
+        final String stringValue = "ABC";
+        final long longValue = 123;
+
+        NSCache cache = new NSCache();
+        // We don't want to have any reference to the CustomNSObject. 
+        // If it were not stored with the ownership helper, it would get GCed immediately.
+        addNewCustomObjectToCache(cache, "1", stringValue, longValue);
+        forceGC();
+
+        CustomNSObject custom = (CustomNSObject) cache.get("1");
+        assertEquals(stringValue, custom.stringValue);
+        assertEquals(longValue, custom.longValue);
+    }
+
+    /**
+     * Custom objects that have been released shouldn't be referenced any longer
+     * on the Java side. But if they are retained again, also reference them
+     * again.
+     */
+    @Test
+    public void testIfCustomObjectsAreCorrectlyReferenced() {
+        CustomUIView custom = new CustomUIView();
+
+        NSCache cache = new NSCache();
+        cache.put("1", custom);
+        assertEquals(true, ObjCObject.ObjectOwnershipHelper.isObjectRetained(custom));
+
+        cache.remove("1");
+        assertEquals(false, ObjCObject.ObjectOwnershipHelper.isObjectRetained(custom));
+
+        cache.put("2", custom);
+        assertEquals(true, ObjCObject.ObjectOwnershipHelper.isObjectRetained(custom));
+
+        cache.remove("2");
+        assertEquals(false, ObjCObject.ObjectOwnershipHelper.isObjectRetained(custom));
+    }
+
+    private static void forceGC() {
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+        }
+    }
+}

--- a/vm/bc/src/bc.c
+++ b/vm/bc/src/bc.c
@@ -967,7 +967,12 @@ Env* _bcAttachThreadFromCallback(void) {
 }
 
 void _bcDetachThreadFromCallback(Env* env) {
-    // Do nothing. The thread will be detached when it terminates.
+    // this may be called after a Java thread
+    // has been destroyed already, e.g. due to
+    // autorelease pool cleanup. See #772
+    if(rvmIsStoppedJavaThread()) {
+        rvmDetachCurrentThread(vm, TRUE, TRUE);
+    }
 }
 
 void* _bcCopyStruct(Env* env, void* src, jint size) {

--- a/vm/core/include/robovm/thread.h
+++ b/vm/core/include/robovm/thread.h
@@ -46,6 +46,11 @@ enum {
     THREAD_MAX_PRIORITY     = 10,
 };
 
+struct StoppedJavaThread {
+    pthread_t thread;
+    struct StoppedJavaThread* next;
+} StoppedJavaThread;
+
 extern jboolean rvmInitThreads(Env* env);
 extern void rvmLockThreadsList();
 extern void rvmUnlockThreadsList();
@@ -61,6 +66,7 @@ extern jint rvmChangeThreadStatus(Env* env, Thread* thread, jint newStatus);
 extern void rvmChangeThreadPriority(Env* env, Thread* thread, jint priority);
 extern void rvmThreadNameChanged(Env* env, Thread* thread);
 extern jboolean rvmHasCurrentThread(Env* env);
+extern jboolean rvmIsStoppedJavaThread();
 
 #endif
 


### PR DESCRIPTION
Temporary fix for #772, may leak memory.

After a Java thread has been torn down and unregistered from the GC, things like autorelease pool cleanup may temporarily re-register the thread with the GC via `_bcAttachCurrentThread` and `_bcDetachCurrentThread`. However, we never unregister in that case (see `bc.c` `_bcDetachCurrentThread`). The thread eventually exits and the GC thinks it's still running, as we never unregister it.

This "fix" sets up a list of stopped Java threads. If `_bcDetachCurrentThread` is called, that list is traversed via a call to `rvmIsStoppedJavaThread`. The function removes the list entry and returns true if the current thread was previously started from the Java side and has already been removed.

Note that this may leak memory of size `StoppedJavaThread` if a Java thread exits and `_bcDetachCurrentThread` is not called after that.

Also note that we can't use TLS. That gets cleared before the autorelease pool clean up.

This fix was tested against #738 which exhibits the `thread_suspend failed` issue more often due to the new way how retain/release are implemented.