### PR TITLE
Option to wrap System.out and .err to Foundation.log (#216)

### DIFF
--- a/cocoatouch/src/main/java/org/robovm/apple/logging/FoundationLogPrintStream.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/logging/FoundationLogPrintStream.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015 Trillian Mobile AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robovm.apple.logging;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import org.robovm.apple.foundation.Foundation;
+
+public class FoundationLogPrintStream extends PrintStream {
+
+    StringBuffer st = new StringBuffer();
+
+    public FoundationLogPrintStream() {
+        super(new OutputStream() {
+            @Override
+            public void write(int arg0) throws IOException {
+            }
+        });
+    }
+
+    public void write(char ch) {
+        if (ch == 0xa) {
+        } else {
+            st.append(ch);
+        }
+    }
+
+    @Override
+    public void flush() {
+        if (st.length() > 0) {
+            Foundation.log(st.toString());
+            st.setLength(0);
+        }
+    }
+
+    @Override
+    public void print(char[] s) {
+        for (char ch : s) {
+            write(ch);
+        }
+    }
+
+    @Override
+    public void print(boolean b) {
+        print(b + "");
+    }
+
+    @Override
+    public void print(char c) {
+        write(c);
+    }
+
+    @Override
+    public void print(double d) {
+        print(d + "");
+    }
+
+    @Override
+    public void print(float f) {
+        print(f + "");
+    }
+
+    @Override
+    public void print(int i) {
+        print(i + "");
+    }
+
+    @Override
+    public void print(long l) {
+        print(l + "");
+    }
+
+    @Override
+    public void print(Object obj) {
+        print((obj + "").toCharArray());
+    }
+
+    @Override
+    public void print(String s) {
+        print((s + "").toCharArray());
+    }
+
+    @Override
+    public void println() {
+        flush();
+    }
+
+    @Override
+    public void println(boolean x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(char x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(char[] x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(double x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(float x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(int x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(long x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(Object x) {
+        print(x);
+        flush();
+    }
+
+    @Override
+    public void println(String x) {
+        print(x);
+        flush();
+    }
+
+}

--- a/cocoatouch/src/main/java/org/robovm/apple/logging/FoundationLogPrintStream.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/logging/FoundationLogPrintStream.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import org.robovm.apple.foundation.Foundation;
+import org.robovm.apple.foundation.NSString;
 
 public class FoundationLogPrintStream extends PrintStream {
 
@@ -42,7 +43,7 @@ public class FoundationLogPrintStream extends PrintStream {
     @Override
     public void flush() {
         if (st.length() > 0) {
-            Foundation.log(st.toString());
+            Foundation.log("%@", new NSString(st.toString()));
             st.setLength(0);
         }
     }

--- a/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
@@ -332,11 +332,10 @@ import org.robovm.apple.logging.FoundationLogPrintStream;
         if (delegateClass != null) {
             delegateClassName = ObjCClass.getByType(delegateClass).getName();            
         }
-        if ("true".equals(System.getProperty("org.robovm.apple.logging.err"))) {
+        NSObject inCompilerEnv = NSProcessInfo.getSharedProcessInfo().getEnvironment().get("robovmcompilerenv");
+        if (inCompilerEnv == null || !inCompilerEnv.toString().equals("true")) {
             System.setErr(new FoundationLogPrintStream());
             System.err.println("SET System.err to FoundationLogPrintStream");
-        }
-        if ("true".equals(System.getProperty("org.robovm.apple.logging.out"))) {
     		System.setOut(new FoundationLogPrintStream());
             System.out.println("SET System.out to FoundationLogPrintStream");
         }

--- a/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/uikit/UIApplication.java
@@ -33,6 +33,7 @@ import org.robovm.apple.coredata.*;
 import org.robovm.apple.coreimage.*;
 import org.robovm.apple.coretext.*;
 import org.robovm.apple.corelocation.*;
+import org.robovm.apple.logging.FoundationLogPrintStream;
 /*</imports>*/
 
 /*<javadoc>*/
@@ -330,6 +331,14 @@ import org.robovm.apple.corelocation.*;
         String delegateClassName = null;
         if (delegateClass != null) {
             delegateClassName = ObjCClass.getByType(delegateClass).getName();            
+        }
+        if ("true".equals(System.getProperty("org.robovm.apple.logging.err"))) {
+            System.setErr(new FoundationLogPrintStream());
+            System.err.println("SET System.err to FoundationLogPrintStream");
+        }
+        if ("true".equals(System.getProperty("org.robovm.apple.logging.out"))) {
+    		System.setOut(new FoundationLogPrintStream());
+            System.out.println("SET System.out to FoundationLogPrintStream");
         }
         main(argc, argv, principalClassName, delegateClassName);
     }

--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -64,6 +64,7 @@ import com.dd.plist.NSObject;
 import com.dd.plist.NSString;
 import com.dd.plist.PropertyListParser;
 import com.dd.plist.XMLPropertyListParser;
+import java.util.HashMap;
 
 
 /**
@@ -162,6 +163,8 @@ public class IOSTarget extends AbstractTarget {
                 args.add(entry.getKey() + "=" + entry.getValue());
             }
         }
+        args.add("--setenv");
+        args.add("robovmcompilerenv=true");
         if (!launchParameters.getArguments().isEmpty()) {
             args.add("--args");
             args.addAll(launchParameters.getArguments());
@@ -205,9 +208,9 @@ public class IOSTarget extends AbstractTarget {
         
         Map<String, String> env = launchParameters.getEnvironment();
         if (env == null) {
-            env = Collections.emptyMap();
+            env = new HashMap<>();
         }
-        
+        env.put("robovmcompilerenv", "true");
         AppLauncher launcher = new AppLauncher(device, getAppDir()) {
             protected void log(String s, Object ... args) {
                 config.getLogger().debug(s, args);


### PR DESCRIPTION
@ntherning I don't know if this is the most appropriate way of doing it (please advise if it isn't), but I've tried this out and I can know make system.out and err write to the Foundation.log using a system property.