### PR TITLE
Fix for issue #772

### DIFF
--- a/vm/bc/src/bc.c
+++ b/vm/bc/src/bc.c
@@ -967,7 +967,9 @@ Env* _bcAttachThreadFromCallback(void) {
 }
 
 void _bcDetachThreadFromCallback(Env* env) {
-    // Do nothing. The thread will be detached when it terminates.
+    if(rvmHasThreadBeenDetached()) {
+        rvmDetachCurrentThread(vm, TRUE, TRUE);
+    }
 }
 
 void* _bcCopyStruct(Env* env, void* src, jint size) {

--- a/vm/core/include/robovm/thread.h
+++ b/vm/core/include/robovm/thread.h
@@ -61,6 +61,7 @@ extern jint rvmChangeThreadStatus(Env* env, Thread* thread, jint newStatus);
 extern void rvmChangeThreadPriority(Env* env, Thread* thread, jint priority);
 extern void rvmThreadNameChanged(Env* env, Thread* thread);
 extern jboolean rvmHasCurrentThread(Env* env);
+extern jboolean rvmHasThreadBeenDetached();
 
 #endif
 


### PR DESCRIPTION
We keep a list of detached threads. A thread is added to the list either at the end of startThreadEntryPoint (Java thread) or in attachThreadExiting (native thread). Everytime _bcDetachCurrentThread is called, the list is checked, and if the thread is found, it's explicitely detached. The list is cleaned up periodically in startThreadEntryPoint via a call to cleanupDetachedList which uses pthread_kill to check if a thread is still alive. This does not work on Linux, on which we currently leak a minimal amount of memory for every created thread. I opened an issue for this