### PR TITLE
Fix for #817

### DIFF
--- a/vm/core/src/init.c
+++ b/vm/core/src/init.c
@@ -243,7 +243,7 @@ VM* rvmCreateVM(Options* options) {
 }
 
 Env* rvmCreateEnv(VM* vm) {
-    Env* env = gcAllocate(vm->options->enableHooks ? sizeof(DebugEnv) : sizeof(Env));
+    Env* env = gcAllocateUncollectable(vm->options->enableHooks ? sizeof(DebugEnv) : sizeof(Env));
     if (!env) return NULL;
     env->vm = vm;
     if(vm->options->enableHooks) {

--- a/vm/core/src/memory.c
+++ b/vm/core/src/memory.c
@@ -545,7 +545,7 @@ static inline void* gcAllocateObject(size_t size, void* clazz) {
     }
     return m;
 }
-static inline void* gcAllocateUncollectable(size_t size) {
+void* gcAllocateUncollectable(size_t size) {
     void* m = GC_MALLOC_UNCOLLECTABLE(size);
     if (!m) {
         // Force GC and try again
@@ -577,6 +577,10 @@ static inline void* gcAllocateAtomicUncollectable(size_t size) {
         memset(m, 0, size);
     }
     return m;
+}
+
+void gcFree(void* ptr) {
+    GC_free(ptr);
 }
 
 /*

--- a/vm/core/src/private.h
+++ b/vm/core/src/private.h
@@ -38,6 +38,8 @@ extern void gcAddRoot(void* ptr);
 extern void gcAddRoots(void* start, void* end);
 extern uint32_t gcNewDirectBitmapKind(size_t bitmap);
 extern void* gcAllocate(size_t size);
+extern void* gcAllocateUncollectable(size_t size);
+extern void gcFree(void* ptr);
 extern void* allocateMemoryOfKind(Env* env, size_t size, uint32_t kind);
 extern void registerCleanupHandler(Env* env, Object* object, CleanupHandler handler);
 

--- a/vm/core/src/thread.c
+++ b/vm/core/src/thread.c
@@ -434,6 +434,7 @@ static void attachedThreadExiting(Env* env) {
         setThreadTLS(env, env->currentThread);
         detachThread(env, TRUE, TRUE, TRUE);
         addToDetachedList(pthread_self());
+        gcFree(env);
     }
 }
 


### PR DESCRIPTION
When attaching a native thread (e.g. because of GCD), there's a time window where the Env* of that thread is not reachable via the stack. The GC may collect it before the TLS destructor for that thread is called. Any code in the TLS destructor that requires an Env* will hence fail. Fixed by allocating the Env via gcAlloateUncolletable and freeing it in attachedThreadExited (TLS destructor). This way the Env will be scanned by the GC, and we can manually decide when to free it.