### PR TITLE
Fix for #821.

### DIFF
--- a/objc/src/main/java/org/robovm/objc/ObjCObject.java
+++ b/objc/src/main/java/org/robovm/objc/ObjCObject.java
@@ -254,6 +254,11 @@ public abstract class ObjCObject extends NativeObject {
         if (cls == ObjCClass.class) {
             return (T) ObjCClass.toObjCClass(handle);
         }
+        
+        if (!forceType) {
+            ObjCClass objCClass = ObjCClass.getFromObject(handle);
+            forceType = !cls.isAssignableFrom(objCClass.getType()) && !ObjCClass.isObjCProxy(cls);
+        }
 
         synchronized (objcBridgeLock) {
             T o = getPeerObject(handle);


### PR DESCRIPTION
Cocoa frameworks sometimes use internal private types as return types for public functions. In these cases we need to force the type because there is no corresponding Java class. Otherwise ObjCObject.toObjCObject would return an instance of the parent type (typically NSObject) and that doesn't implement the methods and properties of the requested type resulting in the crash at #821.