### PR TITLE
align httpcore-4.3 code with the actual implementation to assure API com...

### DIFF
--- a/rt/external/apache-http/src/org/apache/http/message/BasicLineFormatter.java
+++ b/rt/external/apache-http/src/org/apache/http/message/BasicLineFormatter.java
@@ -71,7 +71,7 @@ public class BasicLineFormatter implements LineFormatter {
      * The instance here provides non-customized, default behavior.
      */
     public final static BasicLineFormatter DEFAULT = new BasicLineFormatter();
-
+    public final static BasicLineFormatter INSTANCE = new BasicLineFormatter();
 
 
     // public default constructor

--- a/rt/external/apache-http/src/org/apache/http/message/BasicLineFormatter.java
+++ b/rt/external/apache-http/src/org/apache/http/message/BasicLineFormatter.java
@@ -71,6 +71,7 @@ public class BasicLineFormatter implements LineFormatter {
      * The instance here provides non-customized, default behavior.
      */
     public final static BasicLineFormatter DEFAULT = new BasicLineFormatter();
+    // RoboVM: added, see issue #834 
     public final static BasicLineFormatter INSTANCE = new BasicLineFormatter();
 
 


### PR DESCRIPTION
...patibility

The INSTANCE constant is necessary as it’s part of the actual httpcore-4.3 library as you may see here http://hc.apache.org/httpcomponents-core-4.3.x/httpcore/xref/org/apache/http/message/BasicLineFormatter.html

Without this constant some libraries, e.g. rxjava-apache-http do not work because they depend on the actual httpcore-4.3 version.