### PR TITLE
Automatic support for META-INF/services

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
+++ b/compiler/src/main/java/org/robovm/compiler/AppCompiler.java
@@ -251,6 +251,7 @@ public class AppCompiler {
 
     static void addMetaInfImplementations(Clazzes clazzes, Clazz clazz, Set<Clazz> compiled, Set<Clazz> compileQueue) throws IOException {
         String metaInfName = "META-INF/services/" + clazz.getClassName();
+        IOException throwLater = null;
         for (InputStream is : clazzes.loadResources(metaInfName)) {
             try (BufferedReader r = new BufferedReader(new InputStreamReader(is))) {
                 for (;;) {
@@ -267,7 +268,12 @@ public class AppCompiler {
                         compileQueue.add(implClazz);
                     }
                 }
+            } catch (IOException ex) {
+                throwLater = ex;
             }
+        }
+        if (throwLater != null) {
+            throw throwLater;
         }
     }
 

--- a/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
+++ b/compiler/src/main/java/org/robovm/compiler/clazz/Clazzes.java
@@ -17,6 +17,7 @@
 package org.robovm.compiler.clazz;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -135,6 +136,16 @@ public class Clazzes {
             }
         }
         return clazz;
+    }
+
+    public List<InputStream> loadResources(String resource) throws IOException {
+        List<InputStream> arr = new ArrayList<>();
+        for (Path p : getPaths()) {
+            if (p.contains(resource)) {
+                arr.add(p.open(resource));
+            }
+        }
+        return arr;
     }
 
     public List<Path> getBootclasspathPaths() {

--- a/compiler/src/main/java/org/robovm/compiler/clazz/DirectoryPath.java
+++ b/compiler/src/main/java/org/robovm/compiler/clazz/DirectoryPath.java
@@ -17,7 +17,9 @@
 package org.robovm.compiler.clazz;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +43,12 @@ public class DirectoryPath extends AbstractPath {
     public boolean contains(String file) {
         File f = new File(getFile(), file);
         return f.exists() && f.isFile();
+    }
+
+    @Override
+    public InputStream open(String file) throws IOException {
+        File f = new File(getFile(), file);
+        return new FileInputStream(f);
     }
     
     @Override

--- a/compiler/src/main/java/org/robovm/compiler/clazz/Path.java
+++ b/compiler/src/main/java/org/robovm/compiler/clazz/Path.java
@@ -17,6 +17,8 @@
 package org.robovm.compiler.clazz;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
 import java.util.Set;
 
 /**
@@ -54,4 +56,6 @@ public interface Path {
      * @return {@code true} if it exists, {@code false} otherwise.
      */
     boolean contains(String file);
+    
+    InputStream open(String file) throws IOException;
 }

--- a/compiler/src/main/java/org/robovm/compiler/clazz/ZipFilePath.java
+++ b/compiler/src/main/java/org/robovm/compiler/clazz/ZipFilePath.java
@@ -41,15 +41,20 @@ public class ZipFilePath extends AbstractPath {
     
     @Override
     public boolean contains(String file) {
-        Enumeration<? extends ZipEntry> entries = zipFile.entries();
-        while (entries.hasMoreElements()) {
-            ZipEntry entry = entries.nextElement();
-            if (entry.getName().equals(file) && !entry.isDirectory()) {
-                return true;
-            }
-        }
-        return false;
+        ZipEntry en = zipFile.getEntry(file);
+        return en != null && !en.isDirectory();
     }
+
+    @Override
+    public InputStream open(String file) throws IOException {
+        ZipEntry en = zipFile.getEntry(file);
+        if (en == null) {
+            throw new IOException();
+        }
+        return zipFile.getInputStream(en);
+    }
+    
+    
     
     @Override
     protected Set<Clazz> doListClasses() {

--- a/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
+++ b/compiler/src/test/java/org/robovm/compiler/AppCompilerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2015 Trillian Mobile AB
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.robovm.compiler;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.robovm.compiler.clazz.Clazz;
+import org.robovm.compiler.clazz.Clazzes;
+import org.robovm.compiler.clazz.Path;
+import org.robovm.compiler.config.Config;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public class AppCompilerTest {
+    @Test
+    public void testMetainfServiceImplIsAdded() throws Exception {
+        final Path impl1 = new MockPath("META-INF/services/java.lang.Number", "java.lang.Integer");
+        Clazzes clazzes = createClazzes(impl1);
+        Clazz interfaceClazz = clazzes.load("java/lang/Number");
+
+        Set<Clazz> compiled = new HashSet<>();
+        Set<Clazz> queue = new LinkedHashSet<>();
+        AppCompiler.addMetaInfImplementations(clazzes, interfaceClazz, compiled, queue);
+     
+        assertEquals("One item added to queue: " + queue, 1, queue.size());
+        assertTrue("Integer in queue" + queue, queue.contains(clazzes.load("java/lang/Integer")));
+    }
+
+    @Test
+    public void testMultipleMetainfServiceImplsAdded() throws Exception {
+        final Path impl1 = new MockPath("META-INF/services/java.lang.Number", "java.lang.Integer");
+        final Path impl2 = new MockPath("META-INF/services/java.lang.Number", "java.lang.Long");
+        Clazzes clazzes = createClazzes(impl1, impl2);
+        Clazz interfaceClazz = clazzes.load("java/lang/Number");
+
+        Set<Clazz> compiled = new HashSet<>();
+        Set<Clazz> queue = new LinkedHashSet<>();
+        AppCompiler.addMetaInfImplementations(clazzes, interfaceClazz, compiled, queue);
+     
+        assertEquals("Two items added to queue: " + queue, 2, queue.size());
+        
+        assertTrue("Integer in queue" + queue, queue.contains(clazzes.load("java/lang/Integer")));
+        assertTrue("Long in queue" + queue, queue.contains(clazzes.load("java/lang/Long")));
+    }
+
+    @Test
+    public void testMultilineFile() throws Exception {
+        final Path impl1 = new MockPath("META-INF/services/java.lang.Number", 
+            "# first register Integer\n" +
+            "java.lang.Integer\n" +
+            "# then add Long\n" +
+            "java.lang.Long\n"
+                    + "\n\n\n\n"
+        );
+        Clazzes clazzes = createClazzes(impl1);
+        Clazz interfaceClazz = clazzes.load("java/lang/Number");
+
+        Set<Clazz> compiled = new HashSet<>();
+        Set<Clazz> queue = new LinkedHashSet<>();
+        AppCompiler.addMetaInfImplementations(clazzes, interfaceClazz, compiled, queue);
+     
+        assertEquals("Two items added to queue: " + queue, 2, queue.size());
+        
+        assertTrue("Integer in queue" + queue, queue.contains(clazzes.load("java/lang/Integer")));
+        assertTrue("Long in queue" + queue, queue.contains(clazzes.load("java/lang/Long")));
+    }
+
+    @Test
+    public void testMissingImplIsIgnore() throws Exception {
+        final Path impl1 = new MockPath("META-INF/services/java.lang.Number", "java.lang.Integer");
+        final Path impl2 = new MockPath("META-INF/services/java.lang.Number", "nobody.knows.such.Class");
+        Clazzes clazzes = createClazzes(impl1, impl2);
+        Clazz interfaceClazz = clazzes.load("java/lang/Number");
+
+        Set<Clazz> compiled = new HashSet<>();
+        Set<Clazz> queue = new LinkedHashSet<>();
+        AppCompiler.addMetaInfImplementations(clazzes, interfaceClazz, compiled, queue);
+     
+        assertEquals("Just one item added to queue: " + queue, 1, queue.size());
+        
+        assertTrue("Integer in queue" + queue, queue.contains(clazzes.load("java/lang/Integer")));
+    }
+    
+    private static Clazzes createClazzes(final Path... paths) throws Exception {
+        File home = new File(System.getProperty("java.home"));
+        Config cfg = new Config() {
+        };
+        Clazzes clazzes = new Clazzes(
+                cfg,
+                Collections.nCopies(1, new File(new File(home, "lib"), "rt.jar")),
+                Collections.<File>emptyList()
+        ) {
+            @Override
+            public List<Path> getPaths() {
+                return Arrays.asList(paths);
+            }
+        };
+        return clazzes;
+    }
+    
+    private static final class MockPath implements Path {
+        private final String file;
+        private final String content;
+
+        public MockPath(String file, String content) {
+            this.file = file;
+            this.content = content;
+        }
+        
+        @Override
+        public int getIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public File getFile() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Clazz> listClasses() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Clazz loadGeneratedClass(String internalName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public File getGeneratedClassFile(String internalName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasChangedSince(long timestamp) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isInBootClasspath() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean contains(String file) {
+            return this.file.equals(file);
+        }
+
+        @Override
+        public InputStream open(String file) throws IOException {
+            if (this.file.equals(file)) {
+                return new ByteArrayInputStream(this.content.getBytes("UTF-8"));
+            }
+            throw new IOException();
+        }
+        
+    }
+}


### PR DESCRIPTION
In my projects I use java.util.ServiceLoader quite a lot. The common usage pattern looks like this:
```
for (SomeInterface impl : ServiceLoader.load(SomeInterface.class)) {
  // do something with impl
}
```
However this pattern doesn't work well with RoboVM's class closure computation. There is no direct dependency on the implementation classes, so RoboVM does not include them in its closure automatically. But it could, the behaviour of ServiceLoader is quite strict and one could read the same META-INF/services/pkg.SomeInterface files and include them in the class closure as well.

I am attaching my changes which allow me to remove few of my 

```
 <forceLinkClasses>
  <pattern>org.netbeans.html.ko4j.KO4J</pattern>
  <pattern>org.netbeans.html.sound.impl.BrowserAudioEnv</pattern>
</forceLinkClasses>
```
and thus simplify my build scripts. Would you mind accepting them?


