### PR TITLE
alter jlong atomic behaviour to return long

### DIFF
--- a/vm/core/include/robovm/atomic.h
+++ b/vm/core/include/robovm/atomic.h
@@ -30,7 +30,7 @@ static inline jboolean rvmAtomicCompareAndSwapInt(jint* ptr, jint oldval, jint n
 
 static inline jboolean rvmAtomicCompareAndSwapLong(jlong* ptr, jlong oldval, jlong newval) {
 #if defined(DARWIN)
-    return OSAtomicCompareAndSwap64(oldval, newval, ptr) ? TRUE : FALSE;
+    return OSAtomicCompareAndSwapLong(oldval, newval, (long *)ptr) ? TRUE : FALSE;
 #else
     return __sync_bool_compare_and_swap(ptr, oldval, newval) ? TRUE : FALSE;
 #endif
@@ -48,8 +48,8 @@ static inline jint rvmAtomicLoadInt(jint* ptr) {
     return __sync_fetch_and_or(ptr, 0);
 }
 
-static inline jlong rvmAtomicLoadLong(jlong* ptr) {
-    return __sync_fetch_and_or(ptr, 0LL);
+static inline long rvmAtomicLoadLong(jlong* ptr) {
+    return __sync_fetch_and_or((long *)ptr, 0L);
 }
 
 static inline void* rvmAtomicLoadPtr(void** ptr) {

--- a/vm/rt/robovm/sun_misc_Unsafe.c
+++ b/vm/rt/robovm/sun_misc_Unsafe.c
@@ -100,7 +100,7 @@ jint Java_sun_misc_Unsafe_getIntVolatile(Env* env, Object* unsafe, Object* obj, 
 
 jlong Java_sun_misc_Unsafe_getLong(Env* env, Object* unsafe, Object* obj, jlong offset) {
     if (!checkNull(env, obj)) return 0;
-    jlong* address = (jlong*) getFieldAddress(obj, offset);
+    long* address = (long *)getFieldAddress(obj, offset);
     return *address;
 }
 


### PR DESCRIPTION
The current atomic behaviour causes issues with RxJava (see #766) on 32bit devices when performing certain operations such as merges or really anything that uses circular array queue (as it does unsafe ops behind the scenes). This PR fixes such situations.
