### PR TITLE
Fix for #966

### DIFF
--- a/compiler/src/main/resources/header-darwin-arm64.ll
+++ b/compiler/src/main/resources/header-darwin-arm64.ll
@@ -2,8 +2,7 @@
 %BcTrycatchContext = type {%TrycatchContext, i8*}
 
 define private void @checkso() alwaysinline {
-  tail call void asm sideeffect "sub x9, sp, 0x10000", "~{x9},~{dirflag},~{fpsr},~{flags},~{cc}"() nounwind
-  tail call void asm sideeffect "ldr x9, [x9]", "~{x9},~{dirflag},~{fpsr},~{flags},~{cc}"() nounwind
+  tail call void asm sideeffect "sub x9, sp, 0x10000; ldr x9, [x9]", "~{x9},~{dirflag},~{fpsr},~{flags},~{cc}"() nounwind
   ret void
 }
 


### PR DESCRIPTION
 LLVM considers inline asm statements to be separate blocks and reorders them during optimization passes. `checkso` on ARM64 is implemented as multiple IR statements. The optimizer will move them apart, resulting in a crash, as the register `x9` is modified. Moving all assembly code into a single LLVM IR statement fixes the issue