### PR TITLE
NSEntityDescription.insertNewEntityInContext() return value

### DIFF
--- a/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
@@ -131,7 +131,7 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "entityForName:inManagedObjectContext:")
     public static native NSEntityDescription getEntityByNameInContext(String entityName, NSManagedObjectContext context);
     @Method(selector = "insertNewObjectForEntityForName:inManagedObjectContext:")
-    public static native NSObject insertNewEntityInContext(String entityName, NSManagedObjectContext context);
+    public static native NSManagedObject insertNewEntityInContext(String entityName, NSManagedObjectContext context);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder aCoder);
     /*</methods>*/

--- a/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
+++ b/cocoatouch/src/main/java/org/robovm/apple/coredata/NSEntityDescription.java
@@ -131,7 +131,7 @@ import org.robovm.apple.foundation.*;
     @Method(selector = "entityForName:inManagedObjectContext:")
     public static native NSEntityDescription getEntityByNameInContext(String entityName, NSManagedObjectContext context);
     @Method(selector = "insertNewObjectForEntityForName:inManagedObjectContext:")
-    public static native NSEntityDescription insertNewEntityInContext(String entityName, NSManagedObjectContext context);
+    public static native NSObject insertNewEntityInContext(String entityName, NSManagedObjectContext context);
     @Method(selector = "encodeWithCoder:")
     public native void encode(NSCoder aCoder);
     /*</methods>*/


### PR DESCRIPTION
`NSEntityDescription.insertNewEntityInContext()` should return the created `NSManagedObject`, not a `NSEntityDescription` instance:

https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CoreData/Articles/cdCreateMOs.html

Since the return [type is id](https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/CoreDataFramework/Classes/NSEntityDescription_Class/index.html#//apple_ref/occ/clm/NSEntityDescription/insertNewObjectForEntityForName:inManagedObjectContext:), I think it should be changed to `NSManagedObject` in RoboVM (not sure, however).

**Temporary workaround** - creating the `NSManagedObject` instance by calling the constructor directly:

`NSManagedObject managedObject = new NSManagedObject(
	NSEntityDescription.getEntityByNameInContext(ENTITY,
		managedObjectContext), managedObjectContext);`
