### PR TITLE
Fix for issue 352.

### DIFF
--- a/vm/core/src/class.c
+++ b/vm/core/src/class.c
@@ -95,6 +95,8 @@ Class* array_J;
 Class* array_F;
 Class* array_D;
 
+extern ClassLoader* systemClassLoader;
+
 static Field FIELDS_NOT_LOADED = {0};
 static Method METHODS_NOT_LOADED = {0};
 static Interface INTERFACES_NOT_LOADED = {0};
@@ -750,7 +752,7 @@ jboolean rvmInitPrimitiveWrapperClasses(Env* env) {
 Class* rvmFindClass(Env* env, const char* className) {
     Method* method = rvmGetCallingMethod(env);
     if (rvmExceptionOccurred(env)) return NULL;
-    ClassLoader* classLoader = method ? method->clazz->classLoader : NULL;
+    ClassLoader* classLoader = method ? method->clazz->classLoader : systemClassLoader;
     return rvmFindClassUsingLoader(env, className, classLoader);
 }
 


### PR DESCRIPTION
As discussed, this is the first deliverable from us, the simple fix to use the systemClassLoader in the case that no class loader has been found.