### PR TITLE
Dynamic library & Swift support

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -327,6 +327,17 @@ public class IOSTarget extends AbstractTarget {
         }
         ccArgs.add("-isysroot");
         ccArgs.add(sdk.getRoot().getAbsolutePath());
+        
+        // specify dynamic library loading path
+        libArgs.add("-Xlinker");
+        libArgs.add("-rpath");
+        libArgs.add("-Xlinker");
+        libArgs.add("@executable_path/Frameworks");
+        libArgs.add("-Xlinker");
+        libArgs.add("-rpath");
+        libArgs.add("-Xlinker");
+        libArgs.add("@loader_path/Frameworks");
+        
         super.doBuild(outFile, ccArgs, objectFiles, libArgs);
     }
 


### PR DESCRIPTION
What changed:

1. IOSTarget will adds additional linker flags to specify an rpath pointing to the `Frameworks/` directory inside the app bundle
2. AbstractTarget contains a new method called `copyDynamicFrameworks` which copies all frameworks specified in `robovm.xml` that are not system frameworks.
3. If a framework references Swift runtime libraries, these will also be copied over.
4. Added `nm` and `otool` to `ToolchainUtils`.

This is the first iteration of this feature. Still need to test code signing for ad-hoc/store builds and also not copy the Swift libraries if the min OS version is 8.3.