### PR TITLE
Fix for static library frameworks.

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -247,32 +247,36 @@ public abstract class AbstractTarget implements Target {
                 new Resource(frameworkDir).walk(new Walker() {
                     @Override
                     public boolean processDir(Resource resource, File dir, File destDir) throws IOException {
-                        return !(dir.getName().equals("Headers") || dir.getName().equals("Modules") || dir.getName()
-                                .equals("_CodeSignature"));
+                        return !(dir.getName().equals("Headers") || dir.getName().equals("PrivateHeaders")
+                                || dir.getName().equals("Modules") || dir.getName()
+                                        .equals("_CodeSignature") || dir.getName().equals("Versions") || dir.getName()
+                                .equals("Documentation"));
                     }
 
                     @Override
                     public void processFile(Resource resource, File file, File destDir) throws IOException {
-                        copyFile(resource, file, destDir);
+                        if (!isStaticLibrary(file)) {
+                            copyFile(resource, file, destDir);
 
-                        if (file.canExecute()) {
-                            // remove simulator archs for device builds
-                            if (config.getOs() == OS.ios && config.getArch().isArm()) {
-                                File inFile = new File(destDir, file.getName());
-                                File tmpFile = new File(destDir, file.getName() + ".tmp");
-                                ToolchainUtil.lipoRemoveArchs(config, inFile, tmpFile, Arch.x86, Arch.x86_64);
-                                FileUtils.copyFile(tmpFile, inFile);
-                            }
+                            if (isDynamicLibrary(file)) {
+                                // remove simulator archs for device builds
+                                if (config.getOs() == OS.ios && config.getArch().isArm()) {
+                                    File inFile = new File(destDir, file.getName());
+                                    File tmpFile = new File(destDir, file.getName() + ".tmp");
+                                    ToolchainUtil.lipoRemoveArchs(config, inFile, tmpFile, Arch.x86, Arch.x86_64);
+                                    FileUtils.copyFile(tmpFile, inFile);
+                                }
 
-                            // check if this dylib depends on Swift
-                            // and register those libraries to be copied
-                            // to bundle.app/Frameworks
-                            String dependencies = ToolchainUtil.otool(file);
-                            Pattern swiftLibraryPattern = Pattern.compile("libswift.+\\.dylib");
-                            Matcher matcher = swiftLibraryPattern.matcher(dependencies);
-                            while (matcher.find()) {
-                                String library = dependencies.substring(matcher.start(), matcher.end());
-                                swiftLibraries.add(library);
+                                // check if this dylib depends on Swift
+                                // and register those libraries to be copied
+                                // to bundle.app/Frameworks
+                                String dependencies = ToolchainUtil.otool(file);
+                                Pattern swiftLibraryPattern = Pattern.compile("libswift.+\\.dylib");
+                                Matcher matcher = swiftLibraryPattern.matcher(dependencies);
+                                while (matcher.find()) {
+                                    String library = dependencies.substring(matcher.start(), matcher.end());
+                                    swiftLibraries.add(library);
+                                }
                             }
                         }
                     }
@@ -300,6 +304,16 @@ public abstract class AbstractTarget implements Target {
                 }
             }
         }
+    }
+
+    protected boolean isDynamicLibrary(File file) throws IOException {
+        String result = ToolchainUtil.file(file);        
+        return result.contains("shared library");
+    }
+
+    protected boolean isStaticLibrary(File file) throws IOException {
+        String result = ToolchainUtil.file(file);        
+        return result.contains("ar archive");
     }
 
     protected boolean processDir(Resource resource, File dir, File destDir) throws IOException {

--- a/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
+++ b/compiler/src/main/java/org/robovm/compiler/util/ToolchainUtil.java
@@ -48,6 +48,7 @@ public class ToolchainUtil {
     private static String IBTOOL;
     private static String NM;
     private static String OTOOL;
+    private static String FILE;
 
     private static String getIOSDevClang() throws IOException {
         if (IOS_DEV_CLANG == null) {
@@ -117,6 +118,13 @@ public class ToolchainUtil {
             OTOOL = findXcodeCommand("otool", "iphoneos");
         }
         return OTOOL;
+    }
+    
+    private static String getFile() throws IOException {
+        if (FILE == null) {
+            FILE = findXcodeCommand("file", "iphoneos");
+        }
+        return FILE;
     }
 
     private static String getPackageApplication() throws IOException {
@@ -287,7 +295,11 @@ public class ToolchainUtil {
         }
         args.add("-output");
         args.add(outFile);
-        new Executor(config.getLogger(), getLipo()).args(args).exec();
+        new Executor(Logger.NULL_LOGGER, getLipo()).args(args).exec();
+    }
+    
+    public static String file(File file) throws IOException {
+        return new Executor(Logger.NULL_LOGGER, getFile()).args(file).execCapture();
     }
 
     public static void packageApplication(Config config, File appDir, File outFile) throws IOException {


### PR DESCRIPTION
We only copy resources and dynamic libraries and exclude static libraries. Also added a few more framework bundle directories that are not required. Added file to ToolchainUtil to decipher if a file is a static library or not.