### PR TITLE
Adding an option to force link swift libs during compilation

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -140,7 +140,7 @@ public class Config {
     private ArrayList<String> forceLinkClasses;
     @ElementList(required = false, entry = "swiftLib")
     private ArrayList<String> forceLinkSwiftLibs;
-    @ElementList(required = false, entry = "libs")
+    @ElementList(required = false, entry = "lib")
     private ArrayList<Lib> libs;
     @ElementList(required = false, entry = "symbol")
     private ArrayList<String> exportedSymbols;

--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -134,7 +134,9 @@ public class Config {
     private ArrayList<String> roots;
     @ElementList(required = false, entry = "pattern")
     private ArrayList<String> forceLinkClasses;
-    @ElementList(required = false, entry = "lib")
+    @ElementList(required = false, entry = "pattern")
+    private ArrayList<String> forceLinkSwiftLibs;
+    @ElementList(required = false, entry = "swiftLib")
     private ArrayList<Lib> libs;
     @ElementList(required = false, entry = "symbol")
     private ArrayList<String> exportedSymbols;
@@ -355,6 +357,9 @@ public class Config {
         return forceLinkClasses == null ? Collections.<String> emptyList()
                 : Collections.unmodifiableList(forceLinkClasses);
     }
+
+    public List<String> getForceLinkSwiftLibs() { return forceLinkSwiftLibs == null ? Collections.<String> emptyList()
+            : Collections.unmodifiableList(forceLinkSwiftLibs); }
 
     public List<String> getExportedSymbols() {
         return exportedSymbols == null ? Collections.<String> emptyList()

--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -134,9 +134,9 @@ public class Config {
     private ArrayList<String> roots;
     @ElementList(required = false, entry = "pattern")
     private ArrayList<String> forceLinkClasses;
-    @ElementList(required = false, entry = "pattern")
-    private ArrayList<String> forceLinkSwiftLibs;
     @ElementList(required = false, entry = "swiftLib")
+    private ArrayList<String> forceLinkSwiftLibs;
+    @ElementList(required = false, entry = "libs")
     private ArrayList<Lib> libs;
     @ElementList(required = false, entry = "symbol")
     private ArrayList<String> exportedSymbols;


### PR DESCRIPTION
A possible workaround for issue #1071 if manually compiling a swift framework as a static lib 