### PR TITLE
Closes #1087, we manually search for additional bridge methods for the interface a lambda implements

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -225,8 +225,8 @@ public class Config {
                 new ObjCMemberPlugin(),
                 new ObjCBlockPlugin(),
                 new AnnotationImplPlugin(),
-                // new LambdaPlugin()
-                new org.robovm.compiler.plugin.lambda2.LambdaPlugin()
+                new LambdaPlugin()
+                //new org.robovm.compiler.plugin.lambda2.LambdaPlugin()
                 ));
         this.loadPluginsFromClassPath();
     }


### PR DESCRIPTION
Had to add a custom implementation of SootMethodType, essentially copying JMethodType.

Tested against the `robovm/tests/robovm` test suite, using both Eclipse' compiler and Javac.