### PR TITLE
Added native methods for getFloat/putFloat of sun.misc.Unsafe

### DIFF
--- a/rt/libcore/libdvm/src/main/java/sun/misc/Unsafe.java
+++ b/rt/libcore/libdvm/src/main/java/sun/misc/Unsafe.java
@@ -252,6 +252,24 @@ public final class Unsafe {
     public native void putInt(Object obj, long offset, int newValue);
 
     /**
+     * Gets an <code>float</code> field from the given object.
+     *
+     * @param obj non-null; object containing the field
+     * @param offset offset to the field within <code>obj</code>
+     * @return the retrieved value
+     */
+    public native float getFloat(Object obj, long offset);
+    
+    /**
+     * Stores an <code>float</code> field into the given object.
+     *
+     * @param obj non-null; object containing the field
+     * @param offset offset to the field within <code>obj</code>
+     * @param newValue the value to store
+     */
+    public native void putFloat(Object obj, long offset, float newValue);
+    
+    /**
      * Lazy set an int field.
      */
     public native void putOrderedInt(Object obj, long offset, int newValue);

--- a/vm/rt/robovm/sun_misc_Unsafe.c
+++ b/vm/rt/robovm/sun_misc_Unsafe.c
@@ -92,6 +92,12 @@ jint Java_sun_misc_Unsafe_getInt(Env* env, Object* unsafe, Object* obj, jlong of
     return *address;
 }
 
+jfloat Java_sun_misc_Unsafe_getFloat(Env* env, Object* unsafe, Object* obj, jlong offset) {
+    if (!checkNull(env, obj)) return 0;
+    jfloat* address = (jfloat*) getFieldAddress(obj, offset);
+    return *address;
+}
+
 jint Java_sun_misc_Unsafe_getIntVolatile(Env* env, Object* unsafe, Object* obj, jlong offset) {
     if (!checkNull(env, obj)) return 0;
     jint* address = (jint*) getFieldAddress(obj, offset);
@@ -125,6 +131,12 @@ Object* Java_sun_misc_Unsafe_getObjectVolatile(Env* env, Object* unsafe, Object*
 void Java_sun_misc_Unsafe_putInt(Env* env, Object* unsafe, Object* obj, jlong offset, jint newValue) {
     if (!checkNull(env, obj)) return;
     jint* address = (jint*) getFieldAddress(obj, offset);
+    *address = newValue;
+}
+
+void Java_sun_misc_Unsafe_putFloat(Env* env, Object* unsafe, Object* obj, jlong offset, jfloat newValue) {
+    if (!checkNull(env, obj)) return;
+    jfloat* address = (jfloat*) getFieldAddress(obj, offset);
     *address = newValue;
 }
 


### PR DESCRIPTION
When I compiled kryo library for robovm I've noticed that there is no getFloat/putFloat methods in classs sun.misc.Unsafe: https://github.com/EsotericSoftware/kryo/blob/7da2f22999b8cc913fa6e9ea107aa441138bb5f1/src/com/esotericsoftware/kryo/serializers/UnsafeCacheFields.java#L84

According to the documentation this class should support this method:
http://www.docjar.com/docs/api/sun/misc/Unsafe.html#putFloat(long, float)