### PR TITLE
Closes #1041, loading system libs just by name no longer works on iOS 9

### DIFF
--- a/rt/robovm/src/main/java/org/robovm/rt/bro/Runtime.java
+++ b/rt/robovm/src/main/java/org/robovm/rt/bro/Runtime.java
@@ -44,6 +44,10 @@ public final class Runtime {
     private static final List<String> searchPaths;
     
     static {
+        searchPaths = setupDyLdPaths();
+    }
+    
+    private static List<String> setupDyLdPaths() {
         List<String> paths = new ArrayList<String>();
         String home = System.getProperty("user.home");
 
@@ -120,9 +124,9 @@ public final class Runtime {
             }
         }
         
-        searchPaths = uniq(paths);
+        return uniq(paths);        
     }
-
+    
     private static List<String> uniq(List<String> l) {
         Set<String> seen = new HashSet<String>();
         List<String> result = new ArrayList<String>();
@@ -134,7 +138,7 @@ public final class Runtime {
         }
         return result;
     }
-    
+
     private static void readLdSoConf(File f, List<String> paths) throws IOException {
         if (!f.exists() || !f.isFile()) {
             return;
@@ -294,6 +298,18 @@ public final class Runtime {
                         handle = Dl.open(name);
                         if (handle == 0L) {
                             handle = Dl.open(libName);
+                            // on iOS 9+, opening just by
+                            // library name does not work anymore.
+                            // We bruteforce through search paths
+                            // instead
+                            if (handle == 0L) {
+                                for (String searchPath: searchPaths) {
+                                    handle = Dl.open(new File(searchPath, libName).getAbsolutePath());
+                                    if(handle != 0L) {
+                                        break;
+                                    }
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
We now brute force search the library if all else fails as a last resort. I also moved the static initializer code into a static method as Eclipse still has issues with debugging static blocks.