### PR TITLE
removed "CFBundleResourceSpecification" according Apple's new guidelines

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
+++ b/compiler/src/main/java/org/robovm/compiler/target/ios/IOSTarget.java
@@ -715,7 +715,6 @@ public class IOSTarget extends AbstractTarget {
         if (isSimulatorArch(arch)) {
             dict.put("CFBundleSupportedPlatforms", new NSArray(new NSString("iPhoneSimulator")));
         } else {
-            dict.put("CFBundleResourceSpecification", "ResourceRules.plist");
             dict.put("CFBundleSupportedPlatforms", new NSArray(new NSString("iPhoneOS")));
             dict.put("DTPlatformVersion", sdk.getPlatformVersion());
             dict.put("DTPlatformBuild", sdk.getPlatformBuild());


### PR DESCRIPTION
To submit apps to the AppStore info.plist file should not contain the "CFBundleResourceSpecification" key anymore...