### PR TITLE
Fix flaky

### DIFF
--- a/cacerts/pom.xml
+++ b/cacerts/pom.xml
@@ -14,7 +14,15 @@
 
   <modules>
     <module>full</module>
-<!--    <module>small</module>
-    <module>tiny</module> -->
+    <!--    <module>small</module>
+        <module>tiny</module> -->
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version> <!-- Use the latest version -->
+    </dependency>
+  </dependencies>
 </project>

--- a/cacerts/pom.xml
+++ b/cacerts/pom.xml
@@ -18,11 +18,4 @@
         <module>tiny</module> -->
   </modules>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom2</artifactId>
-      <version>2.0.6</version> <!-- Use the latest version -->
-    </dependency>
-  </dependencies>
 </project>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -108,6 +108,12 @@
       <version>1.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -173,6 +179,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
+++ b/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
@@ -118,8 +118,13 @@ public class ConfigTest {
 
     @Test
     public void testWriteConsole() throws Exception {
+        // Calculate the relative path
+        File targetFile = new File("libs/libmy.a");
+        File targetFile2 = new File("libs/foo.o");
+        File targetFile3 = new File("foo1.jar");
+        // build actual XML
         Config.Builder builder = new Config.Builder();
-        builder.addClasspathEntry(new File("foo1.jar"));
+        builder.addClasspathEntry(targetFile3);
         builder.addClasspathEntry(new File(tmp, "foo2.jar"));
         builder.addFramework("Foundation");
         builder.addFramework("AppKit");
@@ -144,19 +149,15 @@ public class ConfigTest {
         builder.write(out, wd);
         // Load the expected XML content from a resource file
         String expectedXml = IOUtils.toString(getClass().getResourceAsStream("ConfigTest.console.xml"));
-
-        // Calculate the relative path
-        File targetFile = new File("libs/libmy.a");
-        File targetFile2 = new File("libs/foo.o");
-        File targetFile3 = new File("foo1.jar");
+        String actualXml = out.toString();
         // Modify the XML content in the expectedXml with the calculated relative path
         expectedXml = expectedXml.replace("<lib>libs/libmy.a</lib>", "<lib>" + targetFile.getAbsolutePath() + "</lib>");
         expectedXml = expectedXml.replace("<lib>libs/foo.o</lib>", "<lib>" + targetFile2.getAbsolutePath() + "</lib>");
         expectedXml = expectedXml.replace("<classpathentry>foo1.jar</classpathentry>", "<classpathentry>" + targetFile3.getAbsolutePath() + "</classpathentry>");
-        // sort actual xml using JDOM
-        String actualXml = out.toString();
+        // sort XMLs using JDOM
         String sortedActualXml = getSortedXml(actualXml);
         String sortedExpectedXml = getSortedXml(expectedXml);
+        // test
         assertEquals(sortedExpectedXml, sortedActualXml);
     }
 
@@ -192,15 +193,27 @@ public class ConfigTest {
     
     @Test
     public void testWriteIOS() throws Exception {
+        File infoFile = new File("Info.plist");
+        File entitlementsFile = new File("entitlements.plist");
         Config.Builder builder = new Config.Builder();
         builder.iosSdkVersion("6.1");
-        builder.iosInfoPList(new File("Info.plist"));
-        builder.iosEntitlementsPList(new File("entitlements.plist"));        
+        builder.iosInfoPList(infoFile);
+        builder.iosEntitlementsPList(entitlementsFile);
         builder.targetType(IOSTarget.TYPE);
         
         StringWriter out = new StringWriter();
         builder.write(out, wd);
-        assertEquals(IOUtils.toString(getClass().getResourceAsStream("ConfigTest.ios.xml")), out.toString());
+        // Load the expected XML content from a resource file
+        String expectedXml = IOUtils.toString(getClass().getResourceAsStream("ConfigTest.ios.xml"));
+        String actualXml = out.toString();
+        // Calculate the relative path
+        expectedXml = expectedXml.replace("<iosInfoPList>Info.plist</iosInfoPList>", "<iosInfoPList>" + infoFile.getAbsolutePath() + "</iosInfoPList>");
+        expectedXml = expectedXml.replace("<iosEntitlementsPList>entitlements.plist</iosEntitlementsPList>", "<iosEntitlementsPList>" + entitlementsFile.getAbsolutePath() + "</iosEntitlementsPList>");
+        // sort XMLs using JDOM
+        String sortedActualXml = getSortedXml(actualXml);
+        String sortedExpectedXml = getSortedXml(expectedXml);
+        // test
+        assertEquals(sortedExpectedXml, sortedActualXml);
     }
     
     private File createMergeConfig(File tmpDir, String dir, String id, OS os, Arch arch, boolean jar) throws Exception {

--- a/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
+++ b/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
@@ -173,14 +173,10 @@ public class ConfigTest {
         return sortedXml;
     }
     private void sortElementRecursively(Element element) {
-        //System.out.println("root: " + element.toString());
         List<Element> children = element.getChildren();
-        //System.out.println("children of " + element + " : " + children.toString());
         children.sort(Comparator.comparing(Element::getName));
-        //System.out.println("sorted children : "+ children);
         for (Element child : children) {
             sortElementRecursively(child); // Recursively sort child elements
-            //System.out.println("next root is : "+ child);
         }
     }
 


### PR DESCRIPTION
### Description
Flaky tests are common occurrences in open-source projects, yielding inconsistent results—sometimes passing and sometimes failing—without code changes. NonDex is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. I have resolved two flaky test issues, testWriteConsole and testWriteIOS using NonDex tool, specifically in the ConfigTest class located at `robovm/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java`. 

### Root cause
The root cause of the flakiness was related to that IOUtils.toString reads the content of an InputStream of XML file into a String, but it doesn't guarantee the order or sorting of elements within the content. The order of elements in the String will reflect the order in which the data was read from the InputStream. As a result, when that actual resulting string compares with expected string which is hardcoded, it causes intermittent failures. Furthermore, a persistent issue arises due to the incorrect display of file paths with their respective relative paths.

### Fix
To use JDOM2 libaray, I add dependency to compiler/pom.xml
```xml
<dependency>
    <groupId>org.jdom</groupId>
    <artifactId>jdom2</artifactId>
    <version>2.0.6</version>
    <scope>test</scope>
</dependency>

<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-compiler-plugin</artifactId>
    <configuration>
        <source>8</source>
        <target>8</target>
    </configuration>
</plugin>
```

This test has been resolved by recursive element sorting using JDOM2, which constructs an XML configuration and calculates the relative path for specific file entries in the XML. It then sorts the XML elements using a recursive sorting function sortElementRecursively. After sorting, it compares the sorted actual XML with the sorted expected XML to ensure they match. The primary change is to calculate the relative paths and update the expected XML accordingly. 

This fix is significant because it eliminates the uncertainty introduced by the order of elements in reading XML file, ensuring that the test consistently passes across different test runs. By doing so, we have improved the reliability and stability of our testing suite.

### How to test
Java: openjdk version "11.0.20.1"
Maven: Apache Maven 3.6.3

1. Compile the module
`mvn clean install -pl compiler -am -DskipTests`
2. Run regular tests
`mvn -pl compiler test -Dtest=org.robovm.compiler.config.ConfigTest#testWriteConsole`
`mvn -pl compiler test -Dtest=org.robovm.compiler.config.ConfigTest#testWriteIOS`
3. Run tests with NonDex tool
`mvn -pl compiler edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.robovm.compiler.config.ConfigTest#testWriteConsole`
`mvn -pl compiler edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.robovm.compiler.config.ConfigTest#testWriteIOS`
After fix, all tests pass