### PR TITLE
fixed flacky test on testWriteConsole

### DIFF
--- a/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
+++ b/compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java
@@ -203,7 +203,10 @@ public class ConfigTest {
         
         StringWriter out = new StringWriter();
         builder.write(out, wd);
-        assertEquals(IOUtils.toString(getClass().getResourceAsStream("ConfigTest.ios.xml")), out.toString());
+
+        String trimOut = trimAbsolutePaths(out.toString());
+
+        compareLineByLine(IOUtils.toString(getClass().getResourceAsStream("ConfigTest.ios.xml")), trimOut.toString());
     }
     
     private File createMergeConfig(File tmpDir, String dir, String id, OS os, Arch arch, boolean jar) throws Exception {


### PR DESCRIPTION
Oct 24 update: The test "testWriteIOS" and “testWriteConsole” are both failing due to discrepancies in the ordering of XML elements between the generated and expected outputs, and the comparison between relative paths with absolute paths in XML elements.

To fix the issue, I adjusted the generated output to ensure absolute paths like <lib>/home/user/robovm/compiler/libs/libmy.a</lib> are converted to relative paths <lib>libs/libmy.a</lib>, which matches the expected output. I also added a line-by-line comparison using assertions to ensure all expected lines are present, and no unexpected lines appear, regardless of order.
